### PR TITLE
Fix failing test to match updated home page

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders visit link', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  const linkElement = screen.getByText(/visit us/i);
   expect(linkElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update App test to check for Visit Us text

## Testing
- `yarn test --watchAll=false` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684dbcd14dec832fa0a7af303aee77c8