### PR TITLE
Add KoffeeOS logo

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import logo from './logo.svg';
+import logo from './koffeeos-logo.svg';
 import './App.css';
 
 function App() {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Visit Us link', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  const linkElement = screen.getByText(/visit us/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/src/koffeeos-logo.svg
+++ b/src/koffeeos-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect x="50" y="70" width="100" height="60" rx="10" ry="10" fill="#6f4e37" />
+  <rect x="50" y="50" width="100" height="20" fill="#8b4513" />
+  <path d="M150 80 q20 10 0 40" fill="none" stroke="#6f4e37" stroke-width="10" stroke-linecap="round" />
+  <text x="100" y="150" font-size="24" text-anchor="middle" fill="#6f4e37" font-family="Arial">KoffeeOS</text>
+</svg>


### PR DESCRIPTION
## Summary
- add SVG-based KoffeeOS logo
- reference new logo in app component
- align unit test with displayed link

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a8ebaa77d8832f971ef8cdc0f3de3f