### PR TITLE
Add company selector flow and configurable dashboard KPIs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,61 +1,192 @@
-import logo from './koffeeos-logo.svg';
 import './App.css';
-import { useState } from 'react';
-import { AiOutlineMenu } from 'react-icons/ai';
+import { useEffect, useState } from 'react';
+import { FaUserCircle, FaMoon, FaSun, FaBars } from 'react-icons/fa';
 import Inventory from './components/Inventory';
 import AccountSettings from './components/AccountSettings';
 import Dashboard from './components/Dashboard';
 import Billing from './components/Billing';
 import SideMenu from './components/SideMenu';
+import GreenCoffee from './components/GreenCoffee';
+import RoastedCoffee from './components/RoastedCoffee';
+import Projections from './components/Projections';
+import Management from './components/Management';
+import Providers from './components/Providers';
+import POS from './components/POS';
+import Sales from './components/Sales';
+import Customers from './components/Customers';
+import Finca from './components/Finca';
+import { useAppContext } from './context/AppContext';
+import CompanySelectorModal from './components/CompanySelectorModal';
 
 function App() {
-  const [view, setView] = useState('inventory');
+  const {
+    modules,
+    darkMode,
+    setDarkMode,
+    activeCompany,
+  } = useAppContext();
+  const [view, setView] = useState('greenCoffee');
   const [menuOpen, setMenuOpen] = useState(false);
+  const [userMenu, setUserMenu] = useState(false);
+  const [companyModalOpen, setCompanyModalOpen] = useState(true);
+
+  useEffect(() => {
+    const current = modules.find((m) => m.key === view);
+    if (!current || !current.enabled) {
+      const first = modules.find((m) => m.enabled);
+      if (first) setView(first.key);
+    }
+  }, [modules, view]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', darkMode);
+  }, [darkMode]);
+
+  useEffect(() => {
+    if (!activeCompany) {
+      setCompanyModalOpen(true);
+    }
+  }, [activeCompany]);
+
+  const handleUpgrade = () => {
+    setView('billing');
+    setCompanyModalOpen(false);
+    setUserMenu(false);
+  };
 
   const renderView = () => {
     switch (view) {
+      case 'greenCoffee':
+        return <GreenCoffee />;
+      case 'roastedCoffee':
+        return <RoastedCoffee />;
       case 'dashboard':
         return <Dashboard />;
       case 'billing':
         return <Billing />;
       case 'settings':
         return <AccountSettings />;
+      case 'projections':
+        return <Projections />;
       case 'inventory':
-      default:
         return <Inventory />;
+      case 'providers':
+        return <Providers />;
+      case 'management':
+        return <Management />;
+      case 'pos':
+        return <POS />;
+      case 'sales':
+        return <Sales />;
+      case 'customers':
+        return <Customers />;
+      case 'finca':
+        return <Finca />;
+      default:
+        return <GreenCoffee />;
     }
   };
 
   return (
-    <div className="App min-h-screen flex relative">
+    <div className="App min-h-screen flex relative bg-white dark:bg-gray-900 dark:text-white">
       <SideMenu
         current={view}
         onChange={(v) => {
           setView(v);
           setMenuOpen(false);
         }}
-        className={`fixed sm:static z-10 transform transition-transform ${menuOpen ? 'translate-x-0' : '-translate-x-full'} sm:translate-x-0`}
+        className={`fixed sm:static z-20 transform transition-transform ${
+          menuOpen ? 'translate-x-0' : '-translate-x-full'
+        } sm:translate-x-0`}
       />
-      <div className="flex-1 flex flex-col items-center p-4">
+      {menuOpen && (
+        <div
+          className="fixed inset-0 bg-black opacity-50 sm:hidden z-10"
+          onClick={() => setMenuOpen(false)}
+        ></div>
+      )}
+      <div className="flex-1 flex flex-col p-4 z-0">
         <button
           className="sm:hidden mb-2 self-start"
           onClick={() => setMenuOpen(!menuOpen)}
         >
-          <AiOutlineMenu className="w-6 h-6" />
+          <FaBars className='w-6 h-6' />
         </button>
-        <header className="w-full max-w-4xl text-center">
-          <img src={logo} className="w-24 mx-auto mb-4" alt="logo" />
+        <div className="mb-4 flex flex-col-reverse items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-left">
+            <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Current company</p>
+            <button
+              type="button"
+              onClick={() => setCompanyModalOpen(true)}
+              className="mt-1 inline-flex items-center gap-2 text-base font-semibold text-dark-green transition hover:underline dark:text-white"
+            >
+              {activeCompany ? activeCompany.name : 'Select a company'}
+            </button>
+            {activeCompany?.location && (
+              <p className="text-sm text-gray-500 dark:text-gray-300">{activeCompany.location}</p>
+            )}
+          </div>
+          <div className="flex items-center gap-4 self-end sm:self-auto">
+            <button
+              onClick={() => setDarkMode(!darkMode)}
+              className="rounded-full border border-gray-300 p-2 transition hover:border-dark-green dark:border-gray-700"
+              aria-label="toggle-dark-mode"
+            >
+              {darkMode ? <FaSun /> : <FaMoon />}
+            </button>
+            <div className="relative">
+              <FaUserCircle
+                className="h-7 w-7 cursor-pointer"
+                onClick={() => setUserMenu(!userMenu)}
+              />
+              {userMenu && (
+                <div className="absolute right-0 mt-2 w-40 overflow-hidden rounded-md border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800">
+                  <button
+                    onClick={() => {
+                      setView('settings');
+                      setUserMenu(false);
+                    }}
+                    className="block w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
+                    Profile
+                  </button>
+                  <button
+                    onClick={() => {
+                      setCompanyModalOpen(true);
+                      setUserMenu(false);
+                    }}
+                    className="block w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
+                    Switch company
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+        <div
+          className={`w-full ${
+            view === 'greenCoffee' || view === 'roastedCoffee' || view === 'inventory'
+              ? ''
+              : 'max-w-4xl'
+          } mx-auto text-center flex-1 flex flex-col items-center`}
+        >
           {renderView()}
           <a
-            className="text-sm underline text-gray-600 hover:text-gray-800"
+            className="text-sm underline text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100 mt-4"
             href="https://pulpa.coffee"
             target="_blank"
             rel="noopener noreferrer"
           >
             Visit Us
           </a>
-        </header>
+        </div>
       </div>
+      <CompanySelectorModal
+        open={companyModalOpen}
+        onClose={() => setCompanyModalOpen(false)}
+        onRequestUpgrade={handleUpgrade}
+      />
     </div>
   );
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,52 +1,288 @@
-import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock('react-icons/fa', () => {
+  const NullIcon = () => null;
+  return {
+    FaBars: NullIcon,
+    FaBox: NullIcon,
+    FaCashRegister: NullIcon,
+    FaChartBar: NullIcon,
+    FaChartLine: NullIcon,
+    FaCoffee: NullIcon,
+    FaCog: NullIcon,
+    FaFileInvoiceDollar: NullIcon,
+    FaHandshake: NullIcon,
+    FaLeaf: NullIcon,
+    FaMoon: NullIcon,
+    FaSeedling: NullIcon,
+    FaShoppingCart: NullIcon,
+    FaSun: NullIcon,
+    FaTools: NullIcon,
+    FaUser: NullIcon,
+    FaUserCircle: NullIcon,
+  };
+}, { virtual: true });
+
 import App from './App';
 import Dashboard from './components/Dashboard';
+import Projections from './components/Projections';
+import { AppProvider } from './context/AppContext';
 
 test('renders Visit Us link', () => {
-  render(<App />);
+  render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
   const linkElement = screen.getByText(/visit us/i);
   expect(linkElement).toBeInTheDocument();
 });
 
+test('prompts to select a company on load', () => {
+  render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
+
+  expect(screen.getByText(/Select a company/i)).toBeInTheDocument();
+  expect(screen.getAllByText(/Pulpa Roasters/i).length).toBeGreaterThan(0);
+  fireEvent.click(screen.getByRole('button', { name: /Confirm company/i }));
+  expect(screen.queryByText(/Select a company/i)).not.toBeInTheDocument();
+});
+
 test('renders settings menu', () => {
-  render(<App />);
+  render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Confirm company/i }));
   const menuItem = screen.getByText(/Settings/i);
   expect(menuItem).toBeInTheDocument();
 });
 
 test('renders dashboard menu', () => {
-  render(<App />);
-  const menuItem = screen.getByText(/Dashboard/i);
+  render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Confirm company/i }));
+  const menuItem = screen.getAllByRole('button', { name: /Dashboard/i })[0];
   expect(menuItem).toBeInTheDocument();
 });
 
 test('renders billing menu', () => {
-  render(<App />);
+  render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Confirm company/i }));
   const menuItem = screen.getByText(/Billing/i);
   expect(menuItem).toBeInTheDocument();
 });
 
+test('renders green coffee menu', () => {
+  render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Confirm company/i }));
+  const items = screen.getAllByText(/Green Coffee/i);
+  expect(items.length).toBeGreaterThan(0);
+});
+
+test('renders roasted coffee menu', () => {
+  render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
+  const menuItem = screen.getByText(/Roasted Coffee/i);
+  expect(menuItem).toBeInTheDocument();
+});
+
+test('renders providers menu', () => {
+  render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
+  const menuItem = screen.getByText(/Providers/i);
+  expect(menuItem).toBeInTheDocument();
+});
+
+test('renders customers menu', () => {
+  render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
+  const menuItem = screen.getByText(/Customers/i);
+  expect(menuItem).toBeInTheDocument();
+});
+
 test('renders inventory section', () => {
-  render(<App />);
-  const headerElement = screen.getByText(/Green Coffee/i);
-  expect(headerElement).toBeInTheDocument();
+  render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Confirm company/i }));
+  fireEvent.click(screen.getByText(/Inventory/i));
+  expect(screen.getByRole('heading', { name: /Green Coffee/i })).toBeInTheDocument();
 });
 
-test('renders operations section', () => {
-  render(<App />);
-  const operationsHeader = screen.getByText(/Operations/i);
-  expect(operationsHeader).toBeInTheDocument();
+test('renders roasted section', () => {
+  render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Confirm company/i }));
+  fireEvent.click(screen.getByText(/Inventory/i));
+  expect(
+    screen.getByRole('heading', { name: /Roasted Coffee/i })
+  ).toBeInTheDocument();
 });
 
-test('renders current quantity column', () => {
-  render(<App />);
-  const columnHeader = screen.getByText(/Current Qty/i);
-  expect(columnHeader).toBeInTheDocument();
+  test('renders quantity column', () => {
+    render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Confirm company/i }));
+  fireEvent.click(screen.getByText(/Inventory/i));
+  expect(screen.getAllByText(/Quantity/i)[0]).toBeInTheDocument();
 });
 
 test('renders dashboard charts headings', () => {
+  window.HTMLCanvasElement.prototype.getContext = () => ({});
   window.Chart = jest.fn(() => ({ destroy: jest.fn() }));
-  render(<Dashboard />);
+  render(
+    <AppProvider>
+      <Dashboard />
+    </AppProvider>
+  );
   expect(screen.getByText(/Total Sales by Week/i)).toBeInTheDocument();
   expect(screen.getByText(/Sales by Product Type/i)).toBeInTheDocument();
+});
+
+test('allows configuring dashboard KPIs', () => {
+  window.HTMLCanvasElement.prototype.getContext = () => ({});
+  window.Chart = jest.fn(() => ({ destroy: jest.fn() }));
+  render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /Confirm company/i }));
+  fireEvent.click(screen.getByText(/Dashboard/i));
+  fireEvent.click(screen.getByText(/Configure KPIs/i));
+  expect(screen.getByText(/Choose dashboard KPIs/i)).toBeInTheDocument();
+  fireEvent.click(screen.getByText(/Weekly Sales Trend/i));
+  fireEvent.click(screen.getByRole('button', { name: /Save selection/i }));
+  expect(screen.queryByText(/Total Sales by Week/i)).not.toBeInTheDocument();
+});
+
+test('adds espresso projection', () => {
+  const refills = [
+    {
+      coffee: { name: 'Test Coffee', purchasePrice: '20' },
+      quantity: 1,
+      unit: 'kg',
+    },
+  ];
+
+  render(
+    <AppProvider initialState={{ espressoRefills: refills }}>
+      <Projections />
+    </AppProvider>
+  );
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: '0' } });
+  fireEvent.change(screen.getByPlaceholderText(/Base Size/i), {
+    target: { value: '18' },
+  });
+  fireEvent.change(screen.getByPlaceholderText(/Sale Price/i), {
+    target: { value: '2' },
+  });
+  fireEvent.click(screen.getByText(/Add Projection/i));
+  expect(screen.getByText('Test Coffee')).toBeInTheDocument();
+  expect(screen.getByText('55')).toBeInTheDocument();
+});
+
+test('adds filter projection', () => {
+  const refills = [
+    {
+      coffee: { name: 'Filter Coffee', purchasePrice: '15' },
+      quantity: 1,
+      unit: 'kg',
+    },
+  ];
+
+  render(
+    <AppProvider initialState={{ filterRefills: refills }}>
+      <Projections />
+    </AppProvider>
+  );
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: '0' } });
+  fireEvent.change(screen.getByPlaceholderText(/Base Size/i), {
+    target: { value: '20' },
+  });
+  fireEvent.change(screen.getByPlaceholderText(/Sale Price/i), {
+    target: { value: '3' },
+  });
+  fireEvent.click(screen.getByText(/Add Projection/i));
+  expect(screen.getByText('Filter Coffee')).toBeInTheDocument();
+  expect(screen.getByText('50')).toBeInTheDocument();
+});
+
+test('processes finca lots into green coffee inventory', async () => {
+  render(
+    <AppProvider>
+      <App />
+    </AppProvider>
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Confirm company/i }));
+
+  fireEvent.click(screen.getByRole('button', { name: /Finca/i }));
+
+  fireEvent.change(screen.getByLabelText(/Coffee Name/i), {
+    target: { value: 'Finca Lot' },
+  });
+  fireEvent.change(screen.getByLabelText(/Process/i), {
+    target: { value: 'Honey' },
+  });
+  fireEvent.change(screen.getByLabelText(/^Latas/i), {
+    target: { value: '10' },
+  });
+  fireEvent.change(screen.getByLabelText(/Kg per Lata/i), {
+    target: { value: '12' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /Add Lot/i }));
+
+  expect(screen.getByText('Finca Lot')).toBeInTheDocument();
+
+  const processButtons = screen.getAllByRole('button', { name: /Process/i });
+  fireEvent.click(processButtons[0]);
+
+  fireEvent.change(screen.getByLabelText(/^Sacks/i), {
+    target: { value: '2' },
+  });
+  fireEvent.change(screen.getByLabelText(/Kg per Sack/i), {
+    target: { value: '69' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /Confirm/i }));
+
+  await waitFor(() => expect(screen.getAllByText(/Processed/i)[0]).toBeInTheDocument());
+
+  fireEvent.click(screen.getAllByText(/Green Coffee/i)[0]);
+  await waitFor(() => expect(screen.getByText('Finca Lot')).toBeInTheDocument());
+  expect(screen.getByText('138')).toBeInTheDocument();
 });

--- a/src/components/AccountSettings.jsx
+++ b/src/components/AccountSettings.jsx
@@ -3,10 +3,10 @@ import React from 'react';
 function AccountSettings() {
   return (
     <div className="p-4 bg-white rounded shadow-md">
-      <h2 className="text-xl font-semibold mb-3">Account Settings</h2>
+      <h2 className="text-xl font-semibold mb-3 text-dark-green">Account Settings</h2>
       <div className="flex flex-col gap-2">
-        <button className="px-3 py-1 bg-beige-dark text-gray-800 rounded">Cerrar Sesión</button>
-        <button className="px-3 py-1 bg-beige-dark text-gray-800 rounded">Cerrar Sesión en todos los dispositivos</button>
+        <button className="px-3 py-1 bg-dark-green text-white rounded">Cerrar Sesión</button>
+        <button className="px-3 py-1 bg-dark-green text-white rounded">Cerrar Sesión en todos los dispositivos</button>
       </div>
     </div>
   );

--- a/src/components/CompanySelectorModal.jsx
+++ b/src/components/CompanySelectorModal.jsx
@@ -1,0 +1,166 @@
+import React, { useEffect, useState } from 'react';
+import { useAppContext } from '../context/AppContext';
+
+function CompanySelectorModal({ open, onClose, onRequestUpgrade }) {
+  const { companies, activeCompanyId, setActiveCompanyId } = useAppContext();
+  const [selectedCompanyId, setSelectedCompanyId] = useState(activeCompanyId);
+  const [showUpgrade, setShowUpgrade] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setSelectedCompanyId(activeCompanyId);
+      setShowUpgrade(false);
+    }
+  }, [open, activeCompanyId]);
+
+  if (!open) {
+    return null;
+  }
+
+  const handleConfirm = () => {
+    if (!selectedCompanyId) return;
+    setActiveCompanyId(selectedCompanyId);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-30 flex items-center justify-center bg-black bg-opacity-60 px-4">
+      <div className="w-full max-w-xl rounded-lg bg-white p-6 shadow-xl dark:bg-gray-900">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-dark-green">Select a company</h2>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              Choose which company dashboard you want to manage right now.
+            </p>
+          </div>
+          <button
+            className="text-sm text-gray-500 transition hover:text-gray-700 dark:text-gray-300 dark:hover:text-white"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+
+        {!showUpgrade ? (
+          <div className="mt-6 space-y-4">
+            {companies.length ? (
+              <ul className="space-y-3">
+                {companies.map((company) => (
+                  <li key={company.id}>
+                    <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-gray-200 p-3 transition hover:border-dark-green hover:shadow-sm dark:border-gray-700 dark:hover:border-dark-green">
+                      <input
+                        type="radio"
+                        name="company"
+                        value={company.id}
+                        checked={selectedCompanyId === company.id}
+                        onChange={() => setSelectedCompanyId(company.id)}
+                        className="mt-1 h-4 w-4"
+                      />
+                      <div>
+                        <p className="font-medium text-gray-900 dark:text-white">{company.name}</p>
+                        {company.location && (
+                          <p className="text-sm text-gray-500 dark:text-gray-300">{company.location}</p>
+                        )}
+                        {company.plan && (
+                          <span className="mt-1 inline-block rounded-full bg-dark-green/10 px-2 py-0.5 text-xs font-semibold text-dark-green">
+                            Plan: {company.plan}
+                          </span>
+                        )}
+                      </div>
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                You do not have any companies yet. Upgrade your plan to add one.
+              </p>
+            )}
+            <button
+              type="button"
+              onClick={() => setShowUpgrade(true)}
+              className="w-full rounded-md border border-dark-green px-4 py-2 text-sm font-medium text-dark-green transition hover:bg-dark-green hover:text-white"
+            >
+              Add a new company
+            </button>
+          </div>
+        ) : (
+          <div className="mt-6 space-y-4">
+            <form className="space-y-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="new-company-name">
+                  Company name
+                </label>
+                <input
+                  id="new-company-name"
+                  type="text"
+                  disabled
+                  placeholder="Enter company name"
+                  className="mt-1 w-full rounded-md border border-gray-300 bg-gray-100 px-3 py-2 text-sm text-gray-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="new-company-country">
+                  Country
+                </label>
+                <input
+                  id="new-company-country"
+                  type="text"
+                  disabled
+                  placeholder="Select country"
+                  className="mt-1 w-full rounded-md border border-gray-300 bg-gray-100 px-3 py-2 text-sm text-gray-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                />
+              </div>
+            </form>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              To add more companies to your workspace you need to upgrade your plan. Upgrade now and unlock multi-company support for your team.
+            </p>
+            <button
+              type="button"
+              onClick={onRequestUpgrade}
+              className="w-full rounded-md bg-dark-green px-4 py-2 text-sm font-semibold text-white transition hover:bg-green-700"
+            >
+              Go to upgrade plan
+            </button>
+          </div>
+        )}
+
+        <div className="mt-6 flex justify-end gap-2">
+          {showUpgrade ? (
+            <button
+              type="button"
+              onClick={() => setShowUpgrade(false)}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:border-dark-green hover:text-dark-green dark:border-gray-600 dark:text-gray-200 dark:hover:border-dark-green"
+            >
+              Back
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:border-dark-green hover:text-dark-green dark:border-gray-600 dark:text-gray-200 dark:hover:border-dark-green"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirm}
+                disabled={!selectedCompanyId}
+                className={`rounded-md px-4 py-2 text-sm font-semibold text-white transition ${
+                  selectedCompanyId
+                    ? 'bg-dark-green hover:bg-green-700'
+                    : 'bg-gray-400 cursor-not-allowed'
+                }`}
+              >
+                Confirm company
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CompanySelectorModal;

--- a/src/components/Customers.jsx
+++ b/src/components/Customers.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useAppContext } from '../context/AppContext';
+
+function Customers() {
+  const { customers } = useAppContext();
+  return (
+    <div className="p-4 w-full">
+      <h2 className="text-xl font-semibold mb-4 text-dark-green">Customers</h2>
+      <div className="overflow-x-auto w-full">
+        {customers.length > 0 ? (
+          <table className="min-w-full border-collapse text-sm">
+            <thead>
+              <tr className="bg-dark-green text-white">
+                <th className="border px-2 py-1 text-left">Name</th>
+                <th className="border px-2 py-1 text-left">Email</th>
+                <th className="border px-2 py-1 text-left">Phone</th>
+                <th className="border px-2 py-1 text-left">Purchases</th>
+                <th className="border px-2 py-1 text-left">Revenue</th>
+              </tr>
+            </thead>
+            <tbody>
+              {customers.map((c, idx) => (
+                <tr key={idx} className="odd:bg-dark-green/5 even:bg-white">
+                  <td className="border px-2 py-1">{`${c.firstName || ''} ${c.lastName || ''}`.trim()}</td>
+                  <td className="border px-2 py-1">{c.email}</td>
+                  <td className="border px-2 py-1">{c.phone}</td>
+                  <td className="border px-2 py-1">{c.purchases}</td>
+                  <td className="border px-2 py-1">{c.revenue.toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p>No customers yet.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default Customers;

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,17 +1,179 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import WeeklySalesChart from './WeeklySalesChart';
 import ProductSalesPie from './ProductSalesPie';
-import InventoryTableWidget from './InventoryTableWidget';
+import { useAppContext } from '../context/AppContext';
 
 function Dashboard() {
+  const {
+    greenCoffees = [],
+    roastedCoffees = [],
+    inventory = { green: {}, roasted: {} },
+    bags = [],
+    dashboardKpis,
+    setDashboardKpis,
+    dashboardKpiOptions,
+    activeCompany,
+  } = useAppContext();
+  const [kpiModalOpen, setKpiModalOpen] = useState(false);
+  const [draftSelection, setDraftSelection] = useState(dashboardKpis);
+
+  const totalRevenue = useMemo(
+    () => bags.reduce((sum, bag) => sum + bag.numBags * bag.retailPrice, 0),
+    [bags]
+  );
+  const totalProfit = useMemo(
+    () => bags.reduce((sum, bag) => sum + bag.numBags * (bag.retailPrice - bag.costPrice), 0),
+    [bags]
+  );
+  const selectedKpis = useMemo(() => new Set(dashboardKpis), [dashboardKpis]);
+
+  const openModal = () => {
+    setDraftSelection(dashboardKpis);
+    setKpiModalOpen(true);
+  };
+
+  const toggleDraft = (id) => {
+    setDraftSelection((prev) => {
+      if (prev.includes(id)) {
+        return prev.filter((item) => item !== id);
+      }
+      return [...prev, id];
+    });
+  };
+
+  const applySelection = () => {
+    if (!draftSelection.length) {
+      return;
+    }
+    setDashboardKpis(draftSelection);
+    setKpiModalOpen(false);
+  };
+
   return (
-    <div className="p-4 w-full">
-      <h2 className="text-xl font-semibold mb-4">Dashboard</h2>
-      <div className="grid gap-6 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-2 auto-rows-fr">
-        <WeeklySalesChart />
-        <ProductSalesPie />
-        <InventoryTableWidget />
+    <div className="w-full p-4">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Dashboard</h2>
+          {activeCompany && (
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              Monitoring key metrics for {activeCompany.name}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={openModal}
+          className="self-start rounded-md border border-dark-green px-4 py-2 text-sm font-medium text-dark-green transition hover:bg-dark-green hover:text-white"
+        >
+          Configure KPIs
+        </button>
       </div>
+      {dashboardKpis.length ? (
+        <div className="grid auto-rows-fr gap-6 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-2">
+          {selectedKpis.has('weeklySales') && <WeeklySalesChart />}
+          {selectedKpis.has('productMix') && <ProductSalesPie />}
+          {selectedKpis.has('greenInventory') && (
+            <div className="rounded bg-white p-4 shadow-md dark:bg-gray-800">
+              <h3 className="mb-2 font-semibold text-dark-green">Green Inventory</h3>
+              <ul className="space-y-1 text-sm">
+                {greenCoffees.map((coffee) => (
+                  <li key={coffee.id}>
+                    {coffee.name}: {inventory.green[coffee.id] || 0} kg
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {selectedKpis.has('roastedInventory') && (
+            <div className="rounded bg-white p-4 shadow-md dark:bg-gray-800">
+              <h3 className="mb-2 font-semibold text-dark-green">Roasted Inventory</h3>
+              <ul className="space-y-1 text-sm">
+                {roastedCoffees.map((coffee) => (
+                  <li key={coffee.id}>
+                    {coffee.name}: {inventory.roasted[coffee.id] || 0} kg
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {selectedKpis.has('bagInventory') && (
+            <div className="rounded bg-white p-4 shadow-md dark:bg-gray-800">
+              <h3 className="mb-2 font-semibold text-dark-green">Bags Ready for Sale</h3>
+              <ul className="space-y-1 text-sm">
+                {bags.map((bag, index) => (
+                  <li key={`${bag.coffee.id}-${index}`}>
+                    {bag.coffee.name}: {bag.numBags} bags ({bag.bagWeight}g)
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {selectedKpis.has('projectionSummary') && (
+            <div className="rounded bg-white p-4 shadow-md dark:bg-gray-800">
+              <h3 className="mb-2 font-semibold text-dark-green">Revenue &amp; Profit Projections</h3>
+              <p className="text-sm">Revenue: {totalRevenue.toFixed(2)}</p>
+              <p className="text-sm">Profit: {totalProfit.toFixed(2)}</p>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="rounded border border-dashed border-gray-300 p-8 text-center text-sm text-gray-600 dark:border-gray-700 dark:text-gray-300">
+          Select at least one KPI to visualise insights on your dashboard.
+        </div>
+      )}
+
+      {kpiModalOpen && (
+        <div className="fixed inset-0 z-30 flex items-center justify-center bg-black bg-opacity-60 px-4">
+          <div className="w-full max-w-xl rounded-lg bg-white p-6 shadow-xl dark:bg-gray-900">
+            <h3 className="text-lg font-semibold text-dark-green">Choose dashboard KPIs</h3>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+              Enable the metrics you want to follow closely. You can update this selection anytime.
+            </p>
+            <ul className="mt-4 space-y-3">
+              {dashboardKpiOptions.map((option) => {
+                const checked = draftSelection.includes(option.id);
+                return (
+                  <li key={option.id}>
+                    <label className="flex cursor-pointer items-start gap-3 rounded-md border border-gray-200 p-3 transition hover:border-dark-green hover:shadow-sm dark:border-gray-700 dark:hover:border-dark-green">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleDraft(option.id)}
+                        className="mt-1 h-4 w-4"
+                      />
+                      <div>
+                        <p className="font-medium text-gray-900 dark:text-white">{option.label}</p>
+                        <p className="text-sm text-gray-600 dark:text-gray-300">{option.description}</p>
+                      </div>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+            <div className="mt-6 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setKpiModalOpen(false)}
+                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:border-dark-green hover:text-dark-green dark:border-gray-600 dark:text-gray-200 dark:hover:border-dark-green"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={applySelection}
+                disabled={!draftSelection.length}
+                className={`rounded-md px-4 py-2 text-sm font-semibold text-white transition ${
+                  draftSelection.length
+                    ? 'bg-dark-green hover:bg-green-700'
+                    : 'cursor-not-allowed bg-gray-400'
+                }`}
+              >
+                Save selection
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Finca.jsx
+++ b/src/components/Finca.jsx
@@ -1,0 +1,395 @@
+import React, { useMemo, useState } from 'react';
+import Coffee from '../models/coffee';
+import { useAppContext } from '../context/AppContext';
+
+const processes = ['Washed', 'Honey', 'Natural', 'Anaerobic'];
+
+function Finca() {
+  const {
+    fincaLots,
+    setFincaLots,
+    greenCoffees,
+    setGreenCoffees,
+    setInventory,
+  } = useAppContext();
+  const [form, setForm] = useState({
+    name: '',
+    process: processes[0],
+    latas: '',
+    kgPerLata: '12.5',
+  });
+  const [processingId, setProcessingId] = useState(null);
+  const [processingForm, setProcessingForm] = useState({ sacks: '', kgPerSack: '69' });
+  const [search, setSearch] = useState('');
+
+  const handleFormChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const addLot = (e) => {
+    e.preventDefault();
+    const latas = parseFloat(form.latas);
+    const kgPerLata = parseFloat(form.kgPerLata);
+    if (
+      !form.name.trim() ||
+      !form.process.trim() ||
+      Number.isNaN(latas) ||
+      Number.isNaN(kgPerLata) ||
+      latas <= 0 ||
+      kgPerLata <= 0
+    ) {
+      return;
+    }
+    const estimatedKg = parseFloat((latas * kgPerLata).toFixed(2));
+    const lot = {
+      id: Math.random().toString(36).slice(2, 11),
+      name: form.name.trim(),
+      process: form.process.trim(),
+      latas,
+      kgPerLata,
+      estimatedKg,
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+    };
+    setFincaLots((prev) => [...prev, lot]);
+    setForm((prev) => ({ ...prev, name: '', latas: '', kgPerLata: prev.kgPerLata }));
+  };
+
+  const filteredLots = useMemo(() => {
+    if (!search) return fincaLots;
+    return fincaLots.filter(
+      (lot) =>
+        lot.name.toLowerCase().includes(search.toLowerCase()) ||
+        lot.process.toLowerCase().includes(search.toLowerCase())
+    );
+  }, [fincaLots, search]);
+
+  const startProcessing = (id) => {
+    setProcessingId(id);
+    setProcessingForm({ sacks: '', kgPerSack: '69' });
+  };
+
+  const handleProcessingChange = (e) => {
+    const { name, value } = e.target;
+    setProcessingForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const cancelProcessing = () => {
+    setProcessingId(null);
+    setProcessingForm({ sacks: '', kgPerSack: '69' });
+  };
+
+  const confirmProcessing = (e) => {
+    e.preventDefault();
+    const lot = fincaLots.find((l) => l.id === processingId);
+    if (!lot) return;
+    const sacks = parseFloat(processingForm.sacks);
+    const kgPerSack = parseFloat(processingForm.kgPerSack);
+    if (Number.isNaN(sacks) || Number.isNaN(kgPerSack) || sacks <= 0 || kgPerSack <= 0) {
+      return;
+    }
+    const greenKg = parseFloat((sacks * kgPerSack).toFixed(2));
+    let targetCoffee = greenCoffees.find(
+      (c) =>
+        c.name.toLowerCase() === lot.name.toLowerCase() &&
+        c.process.toLowerCase() === lot.process.toLowerCase()
+    );
+    if (!targetCoffee) {
+      targetCoffee = new Coffee({
+        name: lot.name,
+        process: lot.process,
+        origins: [],
+        providerId: '',
+        producer: '',
+        farm: '',
+        region: '',
+        varietal: '',
+        altitude: '',
+        tastingNotes: '',
+        purchasePrice: '',
+      });
+      setGreenCoffees((prev) => [...prev, targetCoffee]);
+    }
+    const coffeeId = targetCoffee.id;
+    setInventory((prev) => ({
+      ...prev,
+      green: {
+        ...prev.green,
+        [coffeeId]: parseFloat(
+          ((prev.green[coffeeId] || 0) + greenKg).toFixed(2)
+        ),
+      },
+    }));
+    setFincaLots((prev) =>
+      prev.map((item) =>
+        item.id === processingId
+          ? {
+              ...item,
+              status: 'processed',
+              sacks,
+              kgPerSack,
+              greenKg,
+              coffeeId,
+              processedAt: new Date().toISOString(),
+              yield:
+                item.estimatedKg > 0
+                  ? parseFloat(((greenKg / item.estimatedKg) * 100).toFixed(1))
+                  : null,
+            }
+          : item
+      )
+    );
+    cancelProcessing();
+  };
+
+  const totals = useMemo(
+    () => ({
+      pending: filteredLots.filter((lot) => lot.status === 'pending').length,
+      processedKg: filteredLots.reduce((sum, lot) => sum + (lot.greenKg || 0), 0),
+      totalLatas: filteredLots.reduce((sum, lot) => sum + lot.latas, 0),
+    }),
+    [filteredLots]
+  );
+
+  const formatNumber = (value) =>
+    Number.isFinite(value) ? Number(value).toLocaleString(undefined, { maximumFractionDigits: 2 }) : '—';
+
+  return (
+    <div className="p-4 bg-white dark:bg-gray-800 dark:text-white rounded shadow-md mb-6 w-full">
+      <h2 className="text-xl font-semibold mb-1 text-dark-green">KoffeeOS Finca</h2>
+      <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
+        Track cherry lots in latas, convert them into green coffee sacks, and sync the green
+        inventory automatically by coffee name and process.
+      </p>
+
+      <div className="grid sm:grid-cols-3 gap-4 mb-6">
+        <div className="bg-dark-green/10 border border-dark-green/20 rounded p-3">
+          <p className="text-xs uppercase text-dark-green/80">Pending Lots</p>
+          <p className="text-2xl font-semibold text-dark-green">{totals.pending}</p>
+        </div>
+        <div className="bg-dark-green/10 border border-dark-green/20 rounded p-3">
+          <p className="text-xs uppercase text-dark-green/80">Total Latas</p>
+          <p className="text-2xl font-semibold text-dark-green">{formatNumber(totals.totalLatas)}</p>
+        </div>
+        <div className="bg-dark-green/10 border border-dark-green/20 rounded p-3">
+          <p className="text-xs uppercase text-dark-green/80">Green Kg Processed</p>
+          <p className="text-2xl font-semibold text-dark-green">
+            {formatNumber(totals.processedKg)}
+          </p>
+        </div>
+      </div>
+
+      <form onSubmit={addLot} className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <label className="flex flex-col text-left text-sm">
+          Coffee Name
+          <input
+            name="name"
+            value={form.name}
+            onChange={handleFormChange}
+            className="p-2 border rounded"
+            placeholder="Lot name"
+            required
+          />
+        </label>
+        <label className="flex flex-col text-left text-sm">
+          Process
+          <select
+            name="process"
+            value={form.process}
+            onChange={handleFormChange}
+            className="p-2 border rounded"
+          >
+            {processes.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+            {!processes.includes(form.process) && (
+              <option value={form.process}>{form.process}</option>
+            )}
+          </select>
+        </label>
+        <label className="flex flex-col text-left text-sm">
+          Latas
+          <input
+            name="latas"
+            type="number"
+            min="0"
+            step="0.01"
+            value={form.latas}
+            onChange={handleFormChange}
+            className="p-2 border rounded"
+            placeholder="0"
+            required
+          />
+        </label>
+        <label className="flex flex-col text-left text-sm">
+          Kg per Lata
+          <input
+            name="kgPerLata"
+            type="number"
+            min="0"
+            step="0.01"
+            value={form.kgPerLata}
+            onChange={handleFormChange}
+            className="p-2 border rounded"
+            placeholder="12.5"
+            required
+          />
+        </label>
+        <div className="sm:col-span-2 lg:col-span-4 flex justify-end">
+          <button
+            type="submit"
+            className="px-4 py-2 bg-dark-green text-white rounded hover:bg-dark-green/90"
+          >
+            Add Lot
+          </button>
+        </div>
+      </form>
+
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-3">
+        <h3 className="text-lg font-semibold text-dark-green">Lots in Processing</h3>
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by coffee or process"
+          className="p-2 border rounded max-w-xs self-start sm:self-auto"
+        />
+      </div>
+
+      <div className="overflow-x-auto w-full">
+        <table className="min-w-full border-collapse text-sm">
+          <thead>
+            <tr className="bg-dark-green text-white">
+              <th className="border px-2 py-1 text-left">Coffee</th>
+              <th className="border px-2 py-1 text-left">Process</th>
+              <th className="border px-2 py-1 text-left">Latas</th>
+              <th className="border px-2 py-1 text-left">Estimated Kg</th>
+              <th className="border px-2 py-1 text-left">Status</th>
+              <th className="border px-2 py-1 text-left">Sacks</th>
+              <th className="border px-2 py-1 text-left">Green Kg</th>
+              <th className="border px-2 py-1 text-left">Yield %</th>
+              <th className="border px-2 py-1">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredLots.length === 0 && (
+              <tr>
+                <td className="border px-2 py-4 text-center" colSpan={9}>
+                  No lots registered yet.
+                </td>
+              </tr>
+            )}
+            {filteredLots.map((lot) => {
+              const isProcessing = processingId === lot.id;
+              return (
+                <React.Fragment key={lot.id}>
+                  <tr className="odd:bg-dark-green/5 even:bg-white">
+                    <td className="border px-2 py-1">{lot.name}</td>
+                    <td className="border px-2 py-1">{lot.process}</td>
+                    <td className="border px-2 py-1">{formatNumber(lot.latas)}</td>
+                    <td className="border px-2 py-1">{formatNumber(lot.estimatedKg)}</td>
+                    <td className="border px-2 py-1">
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs ${
+                          lot.status === 'processed'
+                            ? 'bg-green-100 text-green-700'
+                            : 'bg-yellow-100 text-yellow-700'
+                        }`}
+                      >
+                        {lot.status === 'processed' ? 'Processed' : 'Pending'}
+                      </span>
+                    </td>
+                    <td className="border px-2 py-1">{formatNumber(lot.sacks)}</td>
+                    <td className="border px-2 py-1">{formatNumber(lot.greenKg)}</td>
+                    <td className="border px-2 py-1">
+                      {lot.yield ? `${formatNumber(lot.yield)}%` : '—'}
+                    </td>
+                    <td className="border px-2 py-1 text-center">
+                      {lot.status === 'pending' ? (
+                        <button
+                          type="button"
+                          onClick={() => startProcessing(lot.id)}
+                          className="text-dark-green underline"
+                        >
+                          Process
+                        </button>
+                      ) : (
+                        <span className="text-xs text-gray-500">
+                          Linked to inventory
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                  {isProcessing && (
+                    <tr>
+                      <td className="border px-2 py-2 bg-dark-green/10" colSpan={9}>
+                        <form
+                          onSubmit={confirmProcessing}
+                          className="flex flex-wrap items-center gap-3"
+                        >
+                          <label className="flex items-center gap-2 text-sm">
+                            Sacks
+                            <input
+                              name="sacks"
+                              type="number"
+                              min="0"
+                              step="0.01"
+                              value={processingForm.sacks}
+                              onChange={handleProcessingChange}
+                              className="p-2 border rounded w-24"
+                              required
+                            />
+                          </label>
+                          <label className="flex items-center gap-2 text-sm">
+                            Kg per Sack
+                            <input
+                              name="kgPerSack"
+                              type="number"
+                              min="0"
+                              step="0.01"
+                              value={processingForm.kgPerSack}
+                              onChange={handleProcessingChange}
+                              className="p-2 border rounded w-24"
+                              required
+                            />
+                          </label>
+                          <span className="text-sm text-dark-green font-medium">
+                            Green Kg:{' '}
+                            {formatNumber(
+                              parseFloat(processingForm.sacks || 0) *
+                                parseFloat(processingForm.kgPerSack || 0)
+                            )}
+                          </span>
+                          <span className="text-sm text-gray-600 dark:text-gray-300">
+                            Will update green coffee for <strong>{lot.name}</strong> ({lot.process}).
+                          </span>
+                          <button
+                            type="submit"
+                            className="px-3 py-1 bg-dark-green text-white rounded"
+                          >
+                            Confirm
+                          </button>
+                          <button
+                            type="button"
+                            onClick={cancelProcessing}
+                            className="px-3 py-1 underline text-red-600"
+                          >
+                            Cancel
+                          </button>
+                        </form>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default Finca;

--- a/src/components/GreenCoffee.jsx
+++ b/src/components/GreenCoffee.jsx
@@ -1,0 +1,367 @@
+import React, { useState } from 'react';
+import countries from '../models/countries';
+import CoffeeModel from '../models/coffee';
+import RoastedCoffee from '../models/roastedCoffee';
+import { useAppContext } from '../context/AppContext';
+
+function GreenCoffee() {
+  const {
+    greenCoffees,
+    setGreenCoffees,
+    roastedCoffees,
+    setRoastedCoffees,
+    providers,
+    inventory,
+    setInventory,
+  } = useAppContext();
+  const initialForm = {
+    name: '',
+    origins: [],
+    providerId: '',
+    producer: '',
+    farm: '',
+    region: '',
+    process: '',
+    varietal: '',
+    altitude: '',
+    tastingNotes: '',
+    purchasePrice: '',
+  };
+
+  const [form, setForm] = useState(initialForm);
+  const [editingIndex, setEditingIndex] = useState(null);
+  const [showForm, setShowForm] = useState(false);
+  const [search, setSearch] = useState('');
+  const [toast, setToast] = useState(null);
+
+  const showToast = (message, isError = false) => {
+    setToast({ message, isError });
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleOriginChange = (e) => {
+    const selected = Array.from(e.target.selectedOptions, (o) => o.value);
+    setForm((prev) => ({ ...prev, origins: selected }));
+  };
+
+  const handleProviderChange = (e) => {
+    const providerId = e.target.value;
+    const provider = providers.find((p) => p.id === providerId);
+    setForm((prev) => ({
+      ...prev,
+      providerId,
+      producer: provider?.name || '',
+      farm: provider?.farm || '',
+      region: provider?.region || '',
+      altitude: provider?.altitude || '',
+      origins: provider ? [provider.country] : [],
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    try {
+      const newCoffee = new CoffeeModel({ ...form, isRoasted: false });
+      if (editingIndex !== null) {
+        setGreenCoffees((prev) =>
+          prev.map((c, i) => (i === editingIndex ? newCoffee : c))
+        );
+      } else {
+        setGreenCoffees((prev) => [...prev, newCoffee]);
+      }
+      setInventory((prev) => ({
+        ...prev,
+        green: { ...prev.green, [newCoffee.id]: prev.green[newCoffee.id] || 0 },
+      }));
+      setForm(initialForm);
+      setEditingIndex(null);
+      setShowForm(false);
+      showToast('Coffee saved');
+    } catch (err) {
+      showToast('Error saving coffee', true);
+    }
+  };
+
+  const handleEdit = (idx) => {
+    setForm({ ...greenCoffees[idx] });
+    setEditingIndex(idx);
+    setShowForm(true);
+  };
+
+  const handleDelete = (idx) => {
+    const coffee = greenCoffees[idx];
+    setGreenCoffees((prev) => prev.filter((_, i) => i !== idx));
+    setInventory((prev) => {
+      const g = { ...prev.green };
+      delete g[coffee.id];
+      return { ...prev, green: g };
+    });
+    if (editingIndex === idx) {
+      setForm(initialForm);
+      setEditingIndex(null);
+      setShowForm(false);
+    }
+  };
+
+  const handleCreateRoast = (idx) => {
+    const green = greenCoffees[idx];
+    const roastLevel = prompt('Roast level? (Light/Medium/Dark)');
+    const loss = prompt('Percent weight loss?');
+    if (!roastLevel || !loss) return;
+    const roasted = new RoastedCoffee({
+      ...green,
+      roastLevel,
+      loss,
+      purchasePrice: green.purchasePrice,
+    });
+    setRoastedCoffees((prev) => [...prev, roasted]);
+    setInventory((prev) => ({
+      ...prev,
+      roasted: { ...prev.roasted, [roasted.id]: prev.roasted[roasted.id] || 0 },
+    }));
+    showToast('Roast created');
+  };
+
+  const handleAddNew = () => {
+    setForm(initialForm);
+    setEditingIndex(null);
+    setShowForm(true);
+  };
+
+  const renderRow = (coffee, idx) => (
+    <tr key={coffee.id} className="odd:bg-dark-green/5 even:bg-white">
+      <td className="border px-2 py-1">{coffee.name}</td>
+      <td className="border px-2 py-1">{coffee.origins.join(', ')}</td>
+      <td className="border px-2 py-1">{coffee.producer}</td>
+      <td className="border px-2 py-1">{coffee.farm}</td>
+      <td className="border px-2 py-1">{coffee.region}</td>
+      <td className="border px-2 py-1">{coffee.process}</td>
+      <td className="border px-2 py-1">{coffee.varietal}</td>
+      <td className="border px-2 py-1">{coffee.altitude}</td>
+      <td className="border px-2 py-1">{coffee.tastingNotes}</td>
+      <td className="border px-2 py-1">{inventory.green[coffee.id] || 0}</td>
+      <td className="border px-2 py-1">{coffee.purchasePrice}</td>
+      <td className="border px-2 py-1 text-center">
+        <button
+          type="button"
+          onClick={() => handleCreateRoast(idx)}
+          className="text-dark-green underline mr-2"
+        >
+          Create Roast
+        </button>
+        <button
+          type="button"
+          onClick={() => handleEdit(idx)}
+          className="text-blue-600 underline mr-2"
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          onClick={() => handleDelete(idx)}
+          className="text-red-600 underline"
+        >
+          Delete
+        </button>
+      </td>
+    </tr>
+  );
+
+  return (
+    <div className="p-4 bg-white dark:bg-gray-800 dark:text-white rounded shadow-md mb-6 w-full">
+      <h2 className="text-xl font-semibold mb-3 text-dark-green">Green Coffee</h2>
+      <button
+        type="button"
+        onClick={handleAddNew}
+        className="mb-4 px-3 py-1 bg-dark-green text-white rounded"
+      >
+        Add Coffee
+      </button>
+      {showForm && (
+        <form onSubmit={handleSubmit} className="mb-4 flex flex-col gap-2">
+          <input
+            type="text"
+            name="name"
+            value={form.name}
+            onChange={handleChange}
+            placeholder="Coffee Name"
+            className="p-1 border rounded"
+            required
+          />
+          <select
+            name="origins"
+            multiple
+            value={form.origins}
+            onChange={handleOriginChange}
+            className="p-1 border rounded"
+            required
+          >
+            {countries.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+          <select
+            name="providerId"
+            value={form.providerId}
+            onChange={handleProviderChange}
+            className="p-1 border rounded"
+            required
+          >
+            <option value="" disabled>
+              Provider
+            </option>
+            {providers.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name} - {p.farm} ({p.country})
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            name="producer"
+            value={form.producer}
+            onChange={handleChange}
+            placeholder="Producer Name"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="text"
+            name="farm"
+            value={form.farm}
+            onChange={handleChange}
+            placeholder="Farm"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="text"
+            name="region"
+            value={form.region}
+            onChange={handleChange}
+            placeholder="Region"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="text"
+            name="process"
+            value={form.process}
+            onChange={handleChange}
+            placeholder="Process"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="text"
+            name="varietal"
+            value={form.varietal}
+            onChange={handleChange}
+            placeholder="Varietal"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="text"
+            name="altitude"
+            value={form.altitude}
+            onChange={handleChange}
+            placeholder="Altitude"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="text"
+            name="tastingNotes"
+            value={form.tastingNotes}
+            onChange={handleChange}
+            placeholder="Tasting Notes"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="number"
+            name="purchasePrice"
+            value={form.purchasePrice}
+            onChange={handleChange}
+            placeholder="Purchase Price"
+            className="p-1 border rounded"
+            required
+            step="0.01"
+          />
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="px-3 py-1 bg-dark-green text-white rounded min-w-[64px]"
+            >
+              {editingIndex !== null ? 'Save' : 'Add'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setForm(initialForm);
+                setEditingIndex(null);
+                setShowForm(false);
+              }}
+              className="px-3 py-1 bg-gray-200 rounded min-w-[64px]"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+      <div className="overflow-x-auto w-full">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search..."
+          className="p-1 border rounded mb-2"
+        />
+        <table className="min-w-full border-collapse mb-8 text-sm">
+          <thead>
+            <tr className="bg-dark-green text-white">
+              <th className="border px-2 py-1 text-left">Name</th>
+              <th className="border px-2 py-1 text-left">Origins</th>
+              <th className="border px-2 py-1 text-left">Producer</th>
+              <th className="border px-2 py-1 text-left">Farm</th>
+              <th className="border px-2 py-1 text-left">Region</th>
+              <th className="border px-2 py-1 text-left">Process</th>
+              <th className="border px-2 py-1 text-left">Varietal</th>
+              <th className="border px-2 py-1 text-left">Altitude</th>
+              <th className="border px-2 py-1 text-left">Tasting Notes</th>
+              <th className="border px-2 py-1 text-left">Available (kg)</th>
+              <th className="border px-2 py-1 text-left">Purchase Price</th>
+              <th className="border px-2 py-1">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {greenCoffees
+              .filter((c) =>
+                c.name.toLowerCase().includes(search.toLowerCase())
+              )
+              .map((c, idx) => renderRow(c, idx))}
+          </tbody>
+        </table>
+      </div>
+      {toast && (
+        <div
+          className={`fixed bottom-4 right-4 px-4 py-2 rounded shadow-md text-white ${
+            toast.isError ? 'bg-red-500' : 'bg-green-500'
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default GreenCoffee;

--- a/src/components/Inventory.jsx
+++ b/src/components/Inventory.jsx
@@ -1,515 +1,621 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import RoastedCoffee from '../models/roastedCoffee';
+import { useAppContext } from '../context/AppContext';
 
 function Inventory() {
-  const today = new Date().toISOString().split('T')[0];
+  const {
+    greenCoffees,
+    roastedCoffees,
+    setRoastedCoffees,
+    bags,
+    setBags,
+    espressoRefills,
+    setEspressoRefills,
+    filterRefills,
+    setFilterRefills,
+    inventory,
+    setInventory,
+  } = useAppContext();
+  const [greenInventory, setGreenInventory] = useState([]);
+  const [roastedInventory, setRoastedInventory] = useState(
+    roastedCoffees.map((c) => ({ coffee: c, quantity: 0, unit: 'kg' }))
+  );
+  const [greenForm, setGreenForm] = useState({
+    coffeeIndex: '',
+    quantity: '',
+    unit: 'kg',
+  });
+  const [espressoForm, setEspressoForm] = useState({ coffeeIndex: '', quantity: '' });
+  const [filterForm, setFilterForm] = useState({ coffeeIndex: '', quantity: '' });
 
-  const producerCountries = [
-    'Brazil',
-    'Colombia',
-    'Ethiopia',
-    'Vietnam',
-    'Indonesia',
-    'Guatemala',
-    'Mexico',
-    'Peru',
-    'Honduras',
-    'Nicaragua',
-    'Costa Rica',
-    'Kenya',
-    'Rwanda',
-    'Uganda',
-    'India',
-  ];
+  const handleGreenChange = (e) => {
+    const { name, value } = e.target;
+    setGreenForm((prev) => ({ ...prev, [name]: value }));
+  };
 
-  const [greenCoffee, setGreenCoffee] = useState([]);
-  const [roastedCoffee, setRoastedCoffee] = useState([]);
-  const [consumables, setConsumables] = useState([]);
-  const [operations, setOperations] = useState([]);
+  const addGreen = (e) => {
+    e.preventDefault();
+    const coffee = greenCoffees[greenForm.coffeeIndex];
+    const qty = parseFloat(greenForm.quantity);
+    const qtyKg = greenForm.unit === 'kg' ? qty : qty * 0.453592;
+    setGreenInventory((prev) => [
+      ...prev,
+      { coffee, quantity: qty, unit: greenForm.unit },
+    ]);
+    setInventory((prev) => ({
+      ...prev,
+      green: {
+        ...prev.green,
+        [coffee.id]: (prev.green[coffee.id] || 0) + qtyKg,
+      },
+    }));
+    setGreenForm({ coffeeIndex: '', quantity: '', unit: 'kg' });
+  };
 
-  const [greenInput, setGreenInput] = useState({ origin: '', weight: '', unit: 'kg', date: today });
-  const [roastedInput, setRoastedInput] = useState({ blend: '', roastLevel: '', quantity: '', unit: 'kg', date: today, notes: '' });
-  const [consumableInput, setConsumableInput] = useState({ item: '', quantity: '', unit: 'grams' });
-  const [operationInput, setOperationInput] = useState({ item: '', type: 'Add', quantity: '', unit: 'kg', date: today });
+  const handleEspressoChange = (e) => {
+    const { name, value } = e.target;
+    setEspressoForm((prev) => ({ ...prev, [name]: value }));
+  };
 
-  const [editingGreen, setEditingGreen] = useState(null);
-  const [savingGreen, setSavingGreen] = useState(false);
+  const handleFilterChange = (e) => {
+    const { name, value } = e.target;
+    setFilterForm((prev) => ({ ...prev, [name]: value }));
+  };
 
-  const [editingRoasted, setEditingRoasted] = useState(null);
-  const [savingRoasted, setSavingRoasted] = useState(false);
+  const addEspressoRefill = (e) => {
+    e.preventDefault();
+    const entry = roastedInventory[espressoForm.coffeeIndex];
+    if (!entry) return;
+    const qty = parseFloat(espressoForm.quantity);
+    if (isNaN(qty) || qty <= 0 || qty > entry.quantity) return;
+    setRoastedInventory((prev) =>
+      prev.map((r, i) =>
+        i === parseInt(espressoForm.coffeeIndex, 10)
+          ? { ...r, quantity: r.quantity - qty }
+          : r
+      )
+    );
+    setEspressoRefills((prev) => [
+      ...prev,
+      { coffee: entry.coffee, quantity: qty, unit: entry.unit },
+    ]);
+    setEspressoForm({ coffeeIndex: '', quantity: '' });
+  };
 
-  const [editingConsumable, setEditingConsumable] = useState(null);
-  const [savingConsumable, setSavingConsumable] = useState(false);
-  const [editingOperation, setEditingOperation] = useState(null);
-  const [savingOperation, setSavingOperation] = useState(false);
+  const addFilterRefill = (e) => {
+    e.preventDefault();
+    const entry = roastedInventory[filterForm.coffeeIndex];
+    if (!entry) return;
+    const qty = parseFloat(filterForm.quantity);
+    if (isNaN(qty) || qty <= 0 || qty > entry.quantity) return;
+    setRoastedInventory((prev) =>
+      prev.map((r, i) =>
+        i === parseInt(filterForm.coffeeIndex, 10)
+          ? { ...r, quantity: r.quantity - qty }
+          : r
+      )
+    );
+    setFilterRefills((prev) => [
+      ...prev,
+      { coffee: entry.coffee, quantity: qty, unit: entry.unit },
+    ]);
+    setFilterForm({ coffeeIndex: '', quantity: '' });
+  };
 
-  const operationsWithTotals = () => {
-    const totals = {};
-    return operations.map((op) => {
-      const qty = Number(op.quantity);
-      const prev = totals[op.item] || 0;
-      const newTotal = op.type === 'Add' ? prev + qty : prev - qty;
-      totals[op.item] = newTotal;
-      return { ...op, currentQty: `${newTotal} ${op.unit}` };
+  const editRoasted = (index) => {
+    const entry = roastedInventory[index];
+    const qty = parseFloat(prompt('New quantity?', entry.quantity));
+    if (isNaN(qty) || qty < 0) return;
+    const unit = prompt('Unit? (kg/lbs)', entry.unit);
+    if (!unit) return;
+    setRoastedInventory((prev) =>
+      prev.map((r, i) => (i === index ? { ...r, quantity: qty, unit } : r))
+    );
+  };
+
+  useEffect(() => {
+    setRoastedInventory((prev) => {
+      const keys = prev.map((r) => `${r.coffee.name}-${r.coffee.roastLevel || ''}`);
+      const additions = roastedCoffees
+        .filter((c) => !keys.includes(`${c.name}-${c.roastLevel || ''}`))
+        .map((c) => ({ coffee: c, quantity: 0, unit: 'kg' }));
+      return [...prev, ...additions];
+    });
+  }, [roastedCoffees]);
+
+  const createRoastFromGreen = (index) => {
+    const entry = greenInventory[index];
+    const batch = parseFloat(prompt('Green coffee quantity to roast?'));
+    const roastLevel = prompt('Roast level? (Light/Medium/Dark)');
+    const loss = parseFloat(prompt('Percent weight loss?'));
+    if (
+      isNaN(batch) ||
+      isNaN(loss) ||
+      !roastLevel ||
+      batch <= 0 ||
+      batch > entry.quantity
+    )
+      return;
+    const roastedQty = batch * (1 - loss / 100);
+    const batchKg = entry.unit === 'kg' ? batch : batch * 0.453592;
+    const roastedKg = entry.unit === 'kg' ? roastedQty : roastedQty * 0.453592;
+    const existingIdx = roastedInventory.findIndex(
+      (r) => r.coffee.name === entry.coffee.name && r.coffee.roastLevel === roastLevel
+    );
+    if (existingIdx !== -1) {
+      setRoastedInventory((prev) =>
+        prev.map((r, i) =>
+          i === existingIdx ? { ...r, quantity: r.quantity + roastedQty } : r
+        )
+      );
+    } else {
+      const roastedCoffee = new RoastedCoffee({
+        ...entry.coffee,
+        roastLevel,
+        loss: String(loss),
+        purchasePrice: entry.coffee.purchasePrice,
+      });
+      setRoastedCoffees((prev) => [...prev, roastedCoffee]);
+      setRoastedInventory((prev) => [
+        ...prev,
+        { coffee: roastedCoffee, quantity: roastedQty, unit: entry.unit },
+      ]);
+    }
+    setGreenInventory((prev) =>
+      prev.map((g, i) => (i === index ? { ...g, quantity: g.quantity - batch } : g))
+    );
+    setInventory((prev) => {
+      const greenQty = (prev.green[entry.coffee.id] || 0) - batchKg;
+      const roastedQtyPrev = prev.roasted[entry.coffee.id] || 0;
+      const roastedQtyNew = roastedQtyPrev + roastedKg;
+      return {
+        ...prev,
+        green: {
+          ...prev.green,
+          [entry.coffee.id]: parseFloat(greenQty.toFixed(2)),
+        },
+        roasted: {
+          ...prev.roasted,
+          [entry.coffee.id]: parseFloat(roastedQtyNew.toFixed(2)),
+        },
+      };
     });
   };
 
-  const handleChange = (setter) => (e) => {
+  const [bagForm, setBagForm] = useState(null);
+
+  const toGrams = (qty, unit) =>
+    unit === 'kg' ? qty * 1000 : unit === 'lbs' ? qty * 453.592 : qty;
+  const gramsToUnit = (g, unit) =>
+    unit === 'kg' ? g / 1000 : unit === 'lbs' ? g / 453.592 : g;
+
+  const startBagging = (index) =>
+    setBagForm({
+      index,
+      bagWeight: 250,
+      numBags: 1,
+      costPrice: '',
+      retailPrice: '',
+    });
+
+  const handleBagChange = (e) => {
     const { name, value } = e.target;
-    setter((prev) => ({ ...prev, [name]: value }));
+    setBagForm((prev) => {
+      if (name === 'bagWeight') {
+        const entry = roastedInventory[prev.index];
+        const max = Math.floor(
+          toGrams(entry.quantity, entry.unit) / parseInt(value, 10)
+        );
+        return {
+          ...prev,
+          bagWeight: parseInt(value, 10),
+          numBags: Math.min(prev.numBags, Math.max(max, 1)),
+        };
+      }
+      return { ...prev, [name]: value };
+    });
   };
 
-  const handleAdd = (input, setter, dataSetter, defaults) => (e) => {
+  const submitBagForm = (e) => {
     e.preventDefault();
-    dataSetter((prev) => [...prev, input]);
-    setter(defaults);
+    if (!bagForm) return;
+    const entry = roastedInventory[bagForm.index];
+    const bw = parseFloat(bagForm.bagWeight);
+    const nb = parseInt(bagForm.numBags, 10);
+    const cp = parseFloat(bagForm.costPrice);
+    const rp = parseFloat(bagForm.retailPrice);
+    if ([bw, nb, cp, rp].some((v) => isNaN(v) || v <= 0)) return;
+    const totalGrams = bw * nb;
+    const availableGrams = toGrams(entry.quantity, entry.unit);
+    if (totalGrams > availableGrams) return;
+    const newQty = gramsToUnit(availableGrams - totalGrams, entry.unit);
+    setRoastedInventory((prev) =>
+      prev.map((r, i) =>
+        i === bagForm.index ? { ...r, quantity: parseFloat(newQty.toFixed(2)) } : r
+      )
+    );
+    setInventory((prev) => ({
+      ...prev,
+      roasted: {
+        ...prev.roasted,
+        [entry.coffee.id]: parseFloat(
+          ((prev.roasted[entry.coffee.id] || 0) - totalGrams / 1000).toFixed(2)
+        ),
+      },
+    }));
+    setBags((prev) => [
+      ...prev,
+      {
+        coffee: entry.coffee,
+        bagWeight: bw,
+        numBags: nb,
+        costPrice: cp,
+        retailPrice: rp,
+      },
+    ]);
+    setBagForm(null);
   };
 
-  const handleSave = (index, dataSetter, input, setter, defaults, setSaving, setEditing) => (e) => {
-    e.preventDefault();
-    setSaving(true);
-    setTimeout(() => {
-      dataSetter((prev) => prev.map((item, i) => (i === index ? input : item)));
-      setSaving(false);
-      setEditing(null);
-      setter(defaults);
-    }, 1000);
-  };
+  const cancelBagForm = () => setBagForm(null);
 
-  const renderTable = (data, columns, onEdit) => (
-    <table className="w-full border-collapse mb-8 text-sm">
-      <thead>
-        <tr className="bg-beige-dark">
-          {columns.map((col) => (
-            <th key={col.label} className="border px-2 py-1 text-left">
-              {col.label}
-            </th>
-          ))}
-          {onEdit && <th className="border px-2 py-1">Actions</th>}
-        </tr>
-      </thead>
-      <tbody>
-        {data.map((item, idx) => (
-          <tr key={idx} className="odd:bg-white even:bg-beige/50">
-            {columns.map((col) => {
-              const key = col.key;
-              let value = item[key];
-              if ((key === 'weight' || key === 'quantity') && item.unit) {
-                value = `${value} ${item.unit}`;
-              }
-              return (
-                <td key={col.label} className="border px-2 py-1">
-                  {value}
-                </td>
-              );
-            })}
-            {onEdit && (
-              <td className="border px-2 py-1 text-center">
-                <button
-                  type="button"
-                  onClick={() => onEdit(idx)}
-                  className="text-blue-600 underline"
-                >
-                  Edit
-                </button>
-              </td>
-            )}
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
+  const getBagCount = (coffee) =>
+    bags
+      .filter((b) => b.coffee.name === coffee.name)
+      .reduce((sum, b) => sum + b.numBags, 0);
+
+  const bagEntry = bagForm ? roastedInventory[bagForm.index] : null;
+  const bagAvailable = bagEntry ? toGrams(bagEntry.quantity, bagEntry.unit) : 0;
+  const bagMax = bagEntry ? Math.floor(bagAvailable / bagForm.bagWeight) : 0;
+  const bagLeft = bagEntry
+    ? gramsToUnit(
+        Math.max(bagAvailable - bagForm.bagWeight * bagForm.numBags, 0),
+        bagEntry.unit
+      )
+    : 0;
 
   return (
-    <div className="p-4 bg-white rounded shadow-md mb-6">
-      <h2 className="text-xl font-semibold mb-3">Green Coffee</h2>
-      <form
-        onSubmit={
-          editingGreen !== null
-            ? handleSave(
-                editingGreen,
-                setGreenCoffee,
-                greenInput,
-                setGreenInput,
-                { origin: '', weight: '', unit: 'kg', date: today },
-                setSavingGreen,
-                setEditingGreen
-              )
-            : handleAdd(
-                greenInput,
-                setGreenInput,
-                setGreenCoffee,
-                { origin: '', weight: '', unit: 'kg', date: today }
-              )
-        }
-        className="mb-4 flex flex-col sm:flex-row flex-wrap gap-2"
-      >
+    <div className="p-4 bg-white dark:bg-gray-800 dark:text-white rounded shadow-md mb-6 w-full">
+      <h2 className="text-xl font-semibold mb-3 text-dark-green">Inventory</h2>
+      <form onSubmit={addGreen} className="mb-4 flex flex-wrap gap-2 items-end">
         <select
-          name="origin"
-          value={greenInput.origin}
-          onChange={handleChange(setGreenInput)}
+          name="coffeeIndex"
+          value={greenForm.coffeeIndex}
+          onChange={handleGreenChange}
           className="p-1 border rounded flex-1"
           required
         >
           <option value="" disabled>
-            Select Origin
+            Select Green Coffee
           </option>
-          {producerCountries.map((c) => (
-            <option key={c} value={c}>
-              {c}
+          {greenCoffees.map((c, idx) => (
+            <option key={idx} value={idx}>
+              {c.name}
             </option>
           ))}
         </select>
-        <div className="flex flex-1 gap-1">
-          <input
-            type="number"
-            name="weight"
-            value={greenInput.weight}
-            onChange={handleChange(setGreenInput)}
-            placeholder="Weight"
-            className="p-1 border rounded flex-1"
-            required
-          />
-          <select
-            name="unit"
-            value={greenInput.unit}
-            onChange={handleChange(setGreenInput)}
-            className="p-1 border rounded"
-          >
-            <option value="kg">kg</option>
-            <option value="lbs">lbs</option>
-          </select>
-        </div>
-        <input
-          type="date"
-          name="date"
-          value={greenInput.date}
-          onChange={handleChange(setGreenInput)}
-          className="p-1 border rounded flex-1"
-          required
-        />
-        <button
-          type="submit"
-          className="px-3 py-1 bg-beige-dark text-gray-800 rounded flex items-center justify-center min-w-[64px]"
-          disabled={savingGreen}
-        >
-          {savingGreen ? (
-            <span className="w-4 h-4 border-2 border-t-transparent border-gray-800 rounded-full animate-spin" />
-          ) : editingGreen !== null ? (
-            'Save'
-          ) : (
-            'Add'
-          )}
-        </button>
-      </form>
-      {renderTable(
-        greenCoffee,
-        [
-          { label: 'Origin', key: 'origin' },
-          { label: 'Weight', key: 'weight' },
-          { label: 'Date', key: 'date' },
-        ],
-        (idx) => {
-          setEditingGreen(idx);
-          setGreenInput(greenCoffee[idx]);
-        }
-      )}
-
-      <h2 className="text-xl font-semibold mb-3">Roasted Coffee</h2>
-      <form
-        onSubmit={
-          editingRoasted !== null
-            ? handleSave(
-                editingRoasted,
-                setRoastedCoffee,
-                roastedInput,
-                setRoastedInput,
-                { blend: '', roastLevel: '', quantity: '', unit: 'kg', date: today, notes: '' },
-                setSavingRoasted,
-                setEditingRoasted
-              )
-            : handleAdd(
-                roastedInput,
-                setRoastedInput,
-                setRoastedCoffee,
-                { blend: '', roastLevel: '', quantity: '', unit: 'kg', date: today, notes: '' }
-              )
-        }
-        className="mb-4 flex flex-col sm:flex-row flex-wrap gap-2"
-      >
-        <input
-          type="text"
-          name="blend"
-          value={roastedInput.blend}
-          onChange={handleChange(setRoastedInput)}
-          placeholder="Blend"
-          className="p-1 border rounded flex-1"
-          required
-        />
-        <select
-          name="roastLevel"
-          value={roastedInput.roastLevel}
-          onChange={handleChange(setRoastedInput)}
-          className="p-1 border rounded flex-1"
-          required
-        >
-          <option value="" disabled>
-            Roast Level
-          </option>
-          <option value="Light">Light</option>
-          <option value="Medium">Medium</option>
-          <option value="Dark">Dark</option>
-        </select>
-        <div className="flex flex-1 gap-1">
-          <input
-            type="number"
-            name="quantity"
-            value={roastedInput.quantity}
-            onChange={handleChange(setRoastedInput)}
-            placeholder="Quantity"
-            className="p-1 border rounded flex-1"
-            required
-          />
-          <select
-            name="unit"
-            value={roastedInput.unit}
-            onChange={handleChange(setRoastedInput)}
-            className="p-1 border rounded"
-          >
-            <option value="kg">kg</option>
-            <option value="lbs">lbs</option>
-          </select>
-        </div>
-        <input
-          type="date"
-          name="date"
-          value={roastedInput.date}
-          onChange={handleChange(setRoastedInput)}
-          className="p-1 border rounded flex-1"
-          required
-        />
-        <input
-          type="text"
-          name="notes"
-          value={roastedInput.notes}
-          onChange={handleChange(setRoastedInput)}
-          placeholder="Notes"
-          className="p-1 border rounded flex-1"
-        />
-        <button
-          type="submit"
-          className="px-3 py-1 bg-beige-dark text-gray-800 rounded flex items-center justify-center min-w-[64px]"
-          disabled={savingRoasted}
-        >
-          {savingRoasted ? (
-            <span className="w-4 h-4 border-2 border-t-transparent border-gray-800 rounded-full animate-spin" />
-          ) : editingRoasted !== null ? (
-            'Save'
-          ) : (
-            'Add'
-          )}
-        </button>
-      </form>
-      {renderTable(
-        roastedCoffee,
-        [
-          { label: 'Blend', key: 'blend' },
-          { label: 'Roast Level', key: 'roastLevel' },
-          { label: 'Quantity', key: 'quantity' },
-          { label: 'Date', key: 'date' },
-          { label: 'Notes', key: 'notes' },
-        ],
-        (idx) => {
-          setEditingRoasted(idx);
-          setRoastedInput(roastedCoffee[idx]);
-        }
-      )}
-
-      <h2 className="text-xl font-semibold mb-3">Consumables</h2>
-      <form
-        onSubmit={
-          editingConsumable !== null
-            ? handleSave(
-                editingConsumable,
-                setConsumables,
-                consumableInput,
-                setConsumableInput,
-                { item: '', quantity: '', unit: 'grams' },
-                setSavingConsumable,
-                setEditingConsumable
-              )
-            : handleAdd(
-                consumableInput,
-                setConsumableInput,
-                setConsumables,
-                { item: '', quantity: '', unit: 'grams' }
-              )
-        }
-        className="mb-4 flex flex-col sm:flex-row flex-wrap gap-2"
-      >
-        <input
-          type="text"
-          name="item"
-          value={consumableInput.item}
-          onChange={handleChange(setConsumableInput)}
-          placeholder="Item"
-          className="p-1 border rounded flex-1"
-          required
-        />
         <input
           type="number"
           name="quantity"
-          value={consumableInput.quantity}
-          onChange={handleChange(setConsumableInput)}
+          value={greenForm.quantity}
+          onChange={handleGreenChange}
           placeholder="Quantity"
           className="p-1 border rounded flex-1"
           required
         />
         <select
           name="unit"
-          value={consumableInput.unit}
-          onChange={handleChange(setConsumableInput)}
-          className="p-1 border rounded flex-1"
-          required
-        >
-          <option value="grams">grams</option>
-          <option value="kilograms">kilograms</option>
-          <option value="ml">ml</option>
-          <option value="liters">liters</option>
-          <option value="boxes">boxes</option>
-          <option value="units">units</option>
-        </select>
-        <button
-          type="submit"
-          className="px-3 py-1 bg-beige-dark text-gray-800 rounded flex items-center justify-center min-w-[64px]"
-          disabled={savingConsumable}
-        >
-          {savingConsumable ? (
-            <span className="w-4 h-4 border-2 border-t-transparent border-gray-800 rounded-full animate-spin" />
-          ) : editingConsumable !== null ? (
-            'Save'
-          ) : (
-            'Add'
-          )}
-        </button>
-      </form>
-      {renderTable(
-        consumables,
-        [
-          { label: 'Item', key: 'item' },
-          { label: 'Quantity', key: 'quantity' },
-          { label: 'Unit', key: 'unit' },
-        ],
-        (idx) => {
-          setEditingConsumable(idx);
-          setConsumableInput(consumables[idx]);
-        }
-      )}
-
-      <h2 className="text-xl font-semibold mb-3">Operations</h2>
-      <form
-        onSubmit={
-          editingOperation !== null
-            ? handleSave(
-                editingOperation,
-                setOperations,
-                operationInput,
-                setOperationInput,
-                { item: '', type: 'Add', quantity: '', unit: 'kg', date: today },
-                setSavingOperation,
-                setEditingOperation
-              )
-            : handleAdd(
-                operationInput,
-                setOperationInput,
-                setOperations,
-                { item: '', type: 'Add', quantity: '', unit: 'kg', date: today }
-              )
-        }
-        className="mb-4 flex flex-col sm:flex-row flex-wrap gap-2"
-      >
-        <input
-          type="text"
-          name="item"
-          value={operationInput.item}
-          onChange={handleChange(setOperationInput)}
-          placeholder="Item"
-          className="p-1 border rounded flex-1"
-          required
-        />
-        <select
-          name="type"
-          value={operationInput.type}
-          onChange={handleChange(setOperationInput)}
+          value={greenForm.unit}
+          onChange={handleGreenChange}
           className="p-1 border rounded"
         >
-          <option value="Add">Add</option>
-          <option value="Remove">Remove</option>
+          <option value="kg">kg</option>
+          <option value="lbs">lbs</option>
         </select>
-        <div className="flex flex-1 gap-1">
-          <input
-            type="number"
-            name="quantity"
-            value={operationInput.quantity}
-            onChange={handleChange(setOperationInput)}
-            placeholder="Quantity"
-            className="p-1 border rounded flex-1"
-            required
-          />
-          <select
-            name="unit"
-            value={operationInput.unit}
-            onChange={handleChange(setOperationInput)}
-            className="p-1 border rounded"
-          >
-            <option value="kg">kg</option>
-            <option value="lbs">lbs</option>
-            <option value="grams">grams</option>
-            <option value="kilograms">kilograms</option>
-            <option value="ml">ml</option>
-            <option value="liters">liters</option>
-            <option value="boxes">boxes</option>
-            <option value="units">units</option>
-          </select>
-        </div>
+        <button type="submit" className="px-3 py-1 bg-dark-green text-white rounded">
+          Add
+        </button>
+      </form>
+
+      <h3 className="text-lg font-semibold mb-2 text-dark-green">Green Coffee</h3>
+      <div className="overflow-x-auto w-full mb-8">
+        <table className="min-w-full border-collapse text-sm">
+          <thead>
+            <tr className="bg-dark-green text-white">
+              <th className="border px-2 py-1 text-left">Coffee</th>
+              <th className="border px-2 py-1 text-left">Quantity</th>
+              <th className="border px-2 py-1">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {greenInventory.map((g, idx) => (
+              <tr key={idx} className="odd:bg-dark-green/5 even:bg-white">
+                <td className="border px-2 py-1">{g.coffee.name}</td>
+                <td className="border px-2 py-1">
+                  {g.quantity} {g.unit}
+                </td>
+                <td className="border px-2 py-1 text-center">
+                  <button
+                    type="button"
+                    onClick={() => createRoastFromGreen(idx)}
+                    className="text-dark-green underline"
+                  >
+                    Create Roast
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3 className="text-lg font-semibold mb-2 text-dark-green">Roasted Coffee</h3>
+      <div className="overflow-x-auto w-full">
+        <table className="min-w-full border-collapse mb-8 text-sm">
+          <thead>
+            <tr className="bg-dark-green text-white">
+              <th className="border px-2 py-1 text-left">Coffee</th>
+              <th className="border px-2 py-1 text-left">Quantity</th>
+              <th className="border px-2 py-1 text-left">Bags</th>
+              <th className="border px-2 py-1">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {roastedInventory.map((r, idx) => (
+              <React.Fragment key={idx}>
+                <tr className="odd:bg-dark-green/5 even:bg-white">
+                  <td className="border px-2 py-1">{r.coffee.name}</td>
+                  <td className="border px-2 py-1">
+                    {r.quantity} {r.unit}
+                  </td>
+                  <td className="border px-2 py-1">{getBagCount(r.coffee)}</td>
+                  <td className="border px-2 py-1 text-center space-x-2">
+                    <button
+                      type="button"
+                      onClick={() => editRoasted(idx)}
+                      className="text-blue-600 underline"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => startBagging(idx)}
+                      className="text-dark-green underline"
+                    >
+                      Create Bag
+                    </button>
+                  </td>
+                </tr>
+                {bagForm && bagForm.index === idx && (
+                  <tr>
+                    <td colSpan="4" className="border px-2 py-2 bg-dark-green/10">
+                      {bagMax > 0 ? (
+                        <form
+                          onSubmit={submitBagForm}
+                          className="flex flex-wrap items-center gap-2"
+                        >
+                          <label className="flex items-center gap-1">
+                            Size (g)
+                            <select
+                              name="bagWeight"
+                              value={bagForm.bagWeight}
+                              onChange={handleBagChange}
+                              className="border p-1 rounded"
+                            >
+                              <option value={250}>250</option>
+                              <option value={500}>500</option>
+                              <option value={1000}>1000</option>
+                            </select>
+                          </label>
+                          <label className="flex items-center gap-2 flex-1">
+                            Bags
+                            <input
+                              type="range"
+                              name="numBags"
+                              min="1"
+                              max={bagMax}
+                              value={bagForm.numBags}
+                              onChange={handleBagChange}
+                              className="flex-1"
+                            />
+                            <span>{bagForm.numBags}</span>
+                          </label>
+                          <span className="text-sm">
+                            Left: {bagLeft.toFixed(2)} {bagEntry.unit}
+                          </span>
+                          <input
+                            type="number"
+                            name="costPrice"
+                            value={bagForm.costPrice}
+                            onChange={handleBagChange}
+                            placeholder="Cost"
+                            className="border p-1 rounded w-20"
+                            required
+                          />
+                          <input
+                            type="number"
+                            name="retailPrice"
+                            value={bagForm.retailPrice}
+                            onChange={handleBagChange}
+                            placeholder="Retail"
+                            className="border p-1 rounded w-20"
+                            required
+                          />
+                          <button
+                            type="submit"
+                            className="px-2 py-1 bg-dark-green text-white rounded"
+                          >
+                            Save
+                          </button>
+                          <button
+                            type="button"
+                            onClick={cancelBagForm}
+                            className="px-2 py-1 underline text-red-600"
+                          >
+                            Cancel
+                          </button>
+                        </form>
+                      ) : (
+                        <div className="flex justify-between items-center">
+                          <span>Not enough coffee for selected size.</span>
+                          <button
+                            type="button"
+                            onClick={cancelBagForm}
+                            className="px-2 py-1 underline text-red-600"
+                          >
+                            Close
+                          </button>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {bags.length > 0 && (
+        <>
+          <h3 className="text-lg font-semibold mb-2 text-dark-green">
+            Bags for Sale
+          </h3>
+          <div className="overflow-x-auto w-full mb-8">
+            <table className="min-w-full border-collapse text-sm">
+              <thead>
+                <tr className="bg-dark-green text-white">
+                  <th className="border px-2 py-1 text-left">Coffee</th>
+                  <th className="border px-2 py-1 text-left">Bag Size (g)</th>
+                  <th className="border px-2 py-1 text-left">Bags</th>
+                  <th className="border px-2 py-1 text-left">Cost Price</th>
+                  <th className="border px-2 py-1 text-left">Retail Price</th>
+                </tr>
+              </thead>
+              <tbody>
+                {bags.map((b, i) => (
+                  <tr key={i} className="odd:bg-dark-green/5 even:bg-white">
+                    <td className="border px-2 py-1">{b.coffee.name}</td>
+                    <td className="border px-2 py-1">{b.bagWeight}</td>
+                    <td className="border px-2 py-1">{b.numBags}</td>
+                    <td className="border px-2 py-1">{b.costPrice}</td>
+                    <td className="border px-2 py-1">{b.retailPrice}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      <h3 className="text-lg font-semibold mb-2 text-dark-green">Filter Refill</h3>
+      <form onSubmit={addFilterRefill} className="mb-4 flex flex-wrap gap-2 items-end">
+        <select
+          name="coffeeIndex"
+          value={filterForm.coffeeIndex}
+          onChange={handleFilterChange}
+          className="p-1 border rounded flex-1"
+          required
+        >
+          <option value="" disabled>
+            Select Roasted Coffee
+          </option>
+          {roastedInventory.map((r, idx) => (
+            <option key={idx} value={idx}>
+              {r.coffee.name}
+            </option>
+          ))}
+        </select>
         <input
-          type="date"
-          name="date"
-          value={operationInput.date}
-          onChange={handleChange(setOperationInput)}
+          type="number"
+          name="quantity"
+          value={filterForm.quantity}
+          onChange={handleFilterChange}
+          placeholder="Quantity"
           className="p-1 border rounded flex-1"
           required
         />
-        <button
-          type="submit"
-          className="px-3 py-1 bg-beige-dark text-gray-800 rounded flex items-center justify-center min-w-[64px]"
-          disabled={savingOperation}
-        >
-          {savingOperation ? (
-            <span className="w-4 h-4 border-2 border-t-transparent border-gray-800 rounded-full animate-spin" />
-          ) : editingOperation !== null ? (
-            'Save'
-          ) : (
-            'Add'
-          )}
+        <button type="submit" className="px-3 py-1 bg-dark-green text-white rounded">
+          Use
         </button>
       </form>
-      {renderTable(
-        operationsWithTotals(),
-        [
-          { label: 'Item', key: 'item' },
-          { label: 'Type', key: 'type' },
-          { label: 'Quantity', key: 'quantity' },
-          { label: 'Date', key: 'date' },
-          { label: 'Current Qty', key: 'currentQty' },
-        ],
-        (idx) => {
-          setEditingOperation(idx);
-          setOperationInput(operations[idx]);
-        }
+      {filterRefills.length > 0 && (
+        <div className="overflow-x-auto w-full mb-8">
+          <table className="min-w-full border-collapse text-sm">
+            <thead>
+              <tr className="bg-dark-green text-white">
+                <th className="border px-2 py-1 text-left">Coffee</th>
+                <th className="border px-2 py-1 text-left">Quantity</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filterRefills.map((r, idx) => (
+                <tr key={idx} className="odd:bg-dark-green/5 even:bg-white">
+                  <td className="border px-2 py-1">{r.coffee.name}</td>
+                  <td className="border px-2 py-1">
+                    {r.quantity} {r.unit}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <h3 className="text-lg font-semibold mb-2 text-dark-green">Espresso Refill</h3>
+      <form onSubmit={addEspressoRefill} className="mb-4 flex flex-wrap gap-2 items-end">
+        <select
+          name="coffeeIndex"
+          value={espressoForm.coffeeIndex}
+          onChange={handleEspressoChange}
+          className="p-1 border rounded flex-1"
+          required
+        >
+          <option value="" disabled>
+            Select Roasted Coffee
+          </option>
+          {roastedInventory.map((r, idx) => (
+            <option key={idx} value={idx}>
+              {r.coffee.name}
+            </option>
+          ))}
+        </select>
+        <input
+          type="number"
+          name="quantity"
+          value={espressoForm.quantity}
+          onChange={handleEspressoChange}
+          placeholder="Quantity"
+          className="p-1 border rounded flex-1"
+          required
+        />
+        <button type="submit" className="px-3 py-1 bg-dark-green text-white rounded">
+          Use
+        </button>
+      </form>
+      {espressoRefills.length > 0 && (
+        <div className="overflow-x-auto w-full mb-8">
+          <table className="min-w-full border-collapse text-sm">
+            <thead>
+              <tr className="bg-dark-green text-white">
+                <th className="border px-2 py-1 text-left">Coffee</th>
+                <th className="border px-2 py-1 text-left">Quantity</th>
+              </tr>
+            </thead>
+            <tbody>
+              {espressoRefills.map((r, idx) => (
+                <tr key={idx} className="odd:bg-dark-green/5 even:bg-white">
+                  <td className="border px-2 py-1">{r.coffee.name}</td>
+                  <td className="border px-2 py-1">
+                    {r.quantity} {r.unit}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );
 }
 
 export default Inventory;
-

--- a/src/components/InventoryTableWidget.jsx
+++ b/src/components/InventoryTableWidget.jsx
@@ -10,22 +10,24 @@ function InventoryTableWidget() {
   return (
     <div className="bg-white rounded shadow-md p-6">
       <h3 className="text-center mb-2">Current Inventory</h3>
-      <table className="w-full text-sm border-collapse">
-        <thead>
-          <tr className="bg-beige-dark">
-            <th className="border px-2 py-1 text-left">Product</th>
-            <th className="border px-2 py-1 text-left">Quantity</th>
-          </tr>
-        </thead>
-        <tbody>
-          {dummyInventory.map((row, idx) => (
-            <tr key={idx} className="odd:bg-white even:bg-beige/50">
-              <td className="border px-2 py-1">{row.product}</td>
-              <td className="border px-2 py-1">{`${row.qty} ${row.unit}`}</td>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[320px] text-sm border-collapse">
+          <thead>
+            <tr className="bg-beige-dark">
+              <th className="border px-2 py-1 text-left">Product</th>
+              <th className="border px-2 py-1 text-left">Quantity</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {dummyInventory.map((row, idx) => (
+              <tr key={idx} className="odd:bg-white even:bg-beige/50">
+                <td className="border px-2 py-1">{row.product}</td>
+                <td className="border px-2 py-1">{`${row.qty} ${row.unit}`}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/components/Management.jsx
+++ b/src/components/Management.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useAppContext } from '../context/AppContext';
+
+function Management() {
+  const { modules, setModules } = useAppContext();
+  const toggleModule = (key) => {
+    setModules((prev) =>
+      prev.map((m) =>
+        m.key === key ? { ...m, enabled: !m.enabled } : m
+      )
+    );
+  };
+
+  return (
+    <div className="p-4 bg-white rounded shadow-md mb-6 w-full">
+      <h2 className="text-xl font-semibold mb-3 text-dark-green">Management</h2>
+      <div className="overflow-x-auto w-full">
+        <table className="min-w-full border-collapse text-sm">
+          <thead>
+            <tr className="bg-dark-green text-white">
+              <th className="border px-2 py-1 text-left">Module</th>
+              <th className="border px-2 py-1 text-left">Set</th>
+              <th className="border px-2 py-1 text-center">Enabled</th>
+            </tr>
+          </thead>
+          <tbody>
+            {modules.map((m) => (
+              <tr key={m.key} className="odd:bg-dark-green/5 even:bg-white">
+                <td className="border px-2 py-1">{m.name}</td>
+                <td className="border px-2 py-1">{m.group || 'KoffeeOS Core'}</td>
+                <td className="border px-2 py-1 text-center">
+                  <input
+                    type="checkbox"
+                    checked={m.enabled}
+                    onChange={() => toggleModule(m.key)}
+                    disabled={m.key === 'management'}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default Management;

--- a/src/components/POS.jsx
+++ b/src/components/POS.jsx
@@ -1,0 +1,374 @@
+import React, { useMemo, useState } from 'react';
+import { useAppContext } from '../context/AppContext';
+
+const PAYMENT_OPTIONS = [
+  { value: 'cash', label: 'Cash' },
+  { value: 'yappy', label: 'Yappy' },
+  { value: 'card', label: 'Card' },
+  { value: 'gift_card', label: 'Gift Card' },
+];
+
+function POS() {
+  const { bags, setBags, setSales } = useAppContext();
+  const [fullScreen, setFullScreen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [orderItems, setOrderItems] = useState([]);
+  const [paymentMethod, setPaymentMethod] = useState(PAYMENT_OPTIONS[0].value);
+  const [status, setStatus] = useState(null);
+
+  const toggleFullScreen = () => {
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen();
+      setFullScreen(true);
+    } else if (document.exitFullscreen) {
+      document.exitFullscreen();
+      setFullScreen(false);
+    }
+  };
+
+  const filteredBags = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    return bags
+      .map((bag, index) => ({ bag, index }))
+      .filter(({ bag }) => {
+        if (!term) return true;
+        const name = bag.coffee?.name?.toLowerCase() || '';
+        const process = bag.coffee?.process?.toLowerCase() || '';
+        return name.includes(term) || process.includes(term);
+      });
+  }, [bags, searchTerm]);
+
+  const addItemToOrder = (index) => {
+    const bag = bags[index];
+    if (!bag || bag.numBags <= 0) {
+      setStatus({ type: 'error', message: 'Selected item is out of stock.' });
+      return;
+    }
+    setStatus(null);
+    setOrderItems((prev) => {
+      const existing = prev.find((item) => item.bagIndex === index);
+      if (existing) {
+        const maxQty = bag.numBags;
+        if (existing.quantity >= maxQty) {
+          return prev;
+        }
+        return prev.map((item) =>
+          item.bagIndex === index
+            ? { ...item, quantity: Math.min(item.quantity + 1, maxQty) }
+            : item
+        );
+      }
+      return [
+        ...prev,
+        {
+          bagIndex: index,
+          bagName: bag.coffee?.name || 'Coffee',
+          bagWeight: bag.bagWeight,
+          unitPrice: bag.retailPrice,
+          quantity: 1,
+        },
+      ];
+    });
+  };
+
+  const adjustQuantity = (bagIndex, delta) => {
+    const bag = bags[bagIndex];
+    if (!bag) return;
+    setOrderItems((prev) =>
+      prev
+        .map((item) => {
+          if (item.bagIndex !== bagIndex) return item;
+          const maxQty = bag.numBags;
+          const nextQty = Math.max(0, Math.min(item.quantity + delta, maxQty));
+          return { ...item, quantity: nextQty };
+        })
+        .filter((item) => item.quantity > 0)
+    );
+  };
+
+  const removeItem = (bagIndex) => {
+    setOrderItems((prev) => prev.filter((item) => item.bagIndex !== bagIndex));
+  };
+
+  const clearOrder = () => {
+    setOrderItems([]);
+    setStatus(null);
+  };
+
+  const orderTotal = useMemo(
+    () =>
+      orderItems.reduce(
+        (sum, item) => sum + item.quantity * (item.unitPrice || 0),
+        0
+      ),
+    [orderItems]
+  );
+
+  const finalizeSale = () => {
+    if (orderItems.length === 0) return;
+    const insufficient = orderItems.find((item) => {
+      const bag = bags[item.bagIndex];
+      return !bag || bag.numBags < item.quantity;
+    });
+    if (insufficient) {
+      setStatus({
+        type: 'error',
+        message: `Not enough stock for ${insufficient.bagName}.`,
+      });
+      return;
+    }
+
+    const saleRecord = {
+      id: Date.now().toString(),
+      createdAt: new Date().toISOString(),
+      paymentMethod,
+      source: 'POS',
+      items: orderItems.map((item) => ({
+        bagName: item.bagName,
+        bagWeight: item.bagWeight,
+        quantity: item.quantity,
+        unitPrice: item.unitPrice,
+        lineTotal: item.quantity * item.unitPrice,
+      })),
+      total: orderTotal,
+    };
+
+    setSales((prev) => [...prev, saleRecord]);
+    setBags((prev) =>
+      prev.map((bag, idx) => {
+        const match = orderItems.find((item) => item.bagIndex === idx);
+        if (!match) return bag;
+        return { ...bag, numBags: bag.numBags - match.quantity };
+      })
+    );
+
+    setOrderItems([]);
+    setStatus({ type: 'success', message: 'Sale recorded successfully.' });
+  };
+
+  return (
+    <div className="p-4 w-full h-full">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <h2 className="text-2xl font-semibold text-dark-green">Point of Sale</h2>
+        <button
+          onClick={toggleFullScreen}
+          className="px-4 py-2 bg-dark-green text-white rounded shadow"
+        >
+          {fullScreen ? 'Exit Fullscreen' : 'Enter Fullscreen'}
+        </button>
+      </div>
+
+      {status && (
+        <div
+          className={`mb-4 rounded border px-4 py-3 text-sm ${
+            status.type === 'success'
+              ? 'border-green-400 bg-green-50 text-green-700'
+              : 'border-red-400 bg-red-50 text-red-700'
+          }`}
+        >
+          {status.message}
+        </div>
+      )}
+
+      <div className="flex flex-col xl:flex-row gap-6 w-full">
+        <div className="flex-1 bg-gray-50 rounded-lg border border-gray-200 p-4 shadow-sm">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+            <div>
+              <h3 className="text-lg font-semibold text-dark-green">
+                Available Products
+              </h3>
+              <p className="text-sm text-gray-500">
+                Tap an item to add it to the current order.
+              </p>
+            </div>
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder="Search coffee or process"
+              className="w-full sm:w-64 rounded border border-gray-300 px-3 py-2 text-sm focus:border-dark-green focus:outline-none"
+            />
+          </div>
+          {bags.length === 0 ? (
+            <p className="text-center text-sm text-gray-500">
+              No bagged coffee available. Create bags from inventory first.
+            </p>
+          ) : filteredBags.length === 0 ? (
+            <p className="text-center text-sm text-gray-500">
+              No products match your search.
+            </p>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+              {filteredBags.map(({ bag, index }) => {
+                const disabled = bag.numBags <= 0;
+                return (
+                  <button
+                    key={`${bag.coffee?.name || 'coffee'}-${index}`}
+                    type="button"
+                    onClick={() => addItemToOrder(index)}
+                    className={`rounded-lg border px-4 py-3 text-left shadow transition hover:shadow-md focus:outline-none focus:ring-2 focus:ring-dark-green ${
+                      disabled
+                        ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400'
+                        : 'border-gray-200 bg-white text-gray-800'
+                    }`}
+                    disabled={disabled}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-semibold text-dark-green">
+                        {bag.coffee?.name}
+                      </span>
+                      <span className="rounded-full bg-dark-green/10 px-2 py-0.5 text-xs font-medium text-dark-green">
+                        {bag.bagWeight}g
+                      </span>
+                    </div>
+                    <p className="mt-2 text-sm text-gray-500">
+                      {bag.coffee?.process || 'Single Origin'}
+                    </p>
+                    <div className="mt-4 flex items-center justify-between text-sm">
+                      <span className="font-medium text-gray-700">
+                        ${bag.retailPrice.toFixed(2)}
+                      </span>
+                      <span>
+                        {bag.numBags}{' '}
+                        <span className="text-gray-500">in stock</span>
+                      </span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="xl:w-96 flex-shrink-0">
+          <div className="flex h-full flex-col rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div className="border-b border-gray-200 px-4 py-3">
+              <h3 className="text-lg font-semibold text-dark-green">
+                Current Order
+              </h3>
+              <p className="text-xs text-gray-500">
+                Review the ticket before completing the sale.
+              </p>
+            </div>
+            <div className="flex-1 overflow-y-auto px-4 py-3">
+              {orderItems.length === 0 ? (
+                <div className="flex h-full items-center justify-center text-sm text-gray-400">
+                  No items added yet.
+                </div>
+              ) : (
+                <ul className="space-y-3">
+                  {orderItems.map((item) => {
+                    const bag = bags[item.bagIndex];
+                    const maxQty = bag ? bag.numBags : item.quantity;
+                    return (
+                      <li
+                        key={item.bagIndex}
+                        className="rounded border border-gray-200 bg-gray-50 px-3 py-2"
+                      >
+                        <div className="flex items-start justify-between">
+                          <div>
+                            <p className="font-semibold text-dark-green">
+                              {item.bagName}
+                            </p>
+                            <p className="text-xs text-gray-500">
+                              {item.bagWeight}g · ${item.unitPrice.toFixed(2)} each
+                            </p>
+                          </div>
+                          <button
+                            type="button"
+                            className="text-xs text-red-500 hover:underline"
+                            onClick={() => removeItem(item.bagIndex)}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                        <div className="mt-3 flex items-center justify-between">
+                          <div className="inline-flex items-center rounded border border-gray-300 bg-white">
+                            <button
+                              type="button"
+                              className="px-2 py-1 text-sm text-gray-600 hover:bg-gray-100"
+                              onClick={() => adjustQuantity(item.bagIndex, -1)}
+                            >
+                              −
+                            </button>
+                            <span className="px-3 text-sm font-medium text-gray-700">
+                              {item.quantity}
+                            </span>
+                            <button
+                              type="button"
+                              className="px-2 py-1 text-sm text-gray-600 hover:bg-gray-100"
+                              onClick={() => adjustQuantity(item.bagIndex, 1)}
+                              disabled={item.quantity >= maxQty}
+                            >
+                              +
+                            </button>
+                          </div>
+                          <div className="text-right text-sm font-semibold text-gray-700">
+                            ${(item.quantity * item.unitPrice).toFixed(2)}
+                          </div>
+                        </div>
+                        {bag && item.quantity >= bag.numBags && (
+                          <p className="mt-1 text-xs text-amber-600">
+                            Maximum available quantity reached.
+                          </p>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+            <div className="border-t border-gray-200 px-4 py-3">
+              <div className="mb-3">
+                <h4 className="text-sm font-semibold text-dark-green">
+                  Payment Method
+                </h4>
+                <div className="mt-2 grid grid-cols-2 gap-2">
+                  {PAYMENT_OPTIONS.map((option) => (
+                    <button
+                      type="button"
+                      key={option.value}
+                      onClick={() => setPaymentMethod(option.value)}
+                      className={`rounded border px-3 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-dark-green ${
+                        paymentMethod === option.value
+                          ? 'border-dark-green bg-dark-green text-white shadow'
+                          : 'border-gray-300 bg-white text-gray-700 hover:border-dark-green'
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="flex items-center justify-between text-base font-semibold text-gray-800">
+                <span>Total</span>
+                <span>${orderTotal.toFixed(2)}</span>
+              </div>
+              <div className="mt-3 flex gap-2">
+                <button
+                  type="button"
+                  onClick={clearOrder}
+                  className="w-1/3 rounded border border-gray-300 px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+                  disabled={orderItems.length === 0}
+                >
+                  Clear
+                </button>
+                <button
+                  type="button"
+                  onClick={finalizeSale}
+                  className="w-2/3 rounded bg-dark-green px-3 py-2 text-sm font-semibold text-white shadow transition hover:bg-dark-green/90 disabled:cursor-not-allowed disabled:bg-gray-300"
+                  disabled={orderItems.length === 0}
+                >
+                  Complete Sale
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default POS;
+

--- a/src/components/Projections.jsx
+++ b/src/components/Projections.jsx
@@ -1,0 +1,320 @@
+import React, { useState } from 'react';
+import { useAppContext } from '../context/AppContext';
+
+function Projections() {
+  const {
+    bags,
+    espressoRefills,
+    espressoProjections,
+    setEspressoProjections,
+    filterRefills,
+    filterProjections,
+    setFilterProjections,
+  } = useAppContext();
+  const [espressoForm, setEspressoForm] = useState({ refillIndex: '', baseSize: '', salePrice: '' });
+  const [filterForm, setFilterForm] = useState({ refillIndex: '', baseSize: '20', salePrice: '' });
+
+  const addEspressoProjection = (e) => {
+    e.preventDefault();
+    const refill = espressoRefills[espressoForm.refillIndex];
+    const base = parseFloat(espressoForm.baseSize);
+    const sale = parseFloat(espressoForm.salePrice);
+    if (!refill || isNaN(base) || base <= 0 || isNaN(sale) || sale <= 0) return;
+    const grams =
+      refill.unit === 'kg'
+        ? refill.quantity * 1000
+        : refill.unit === 'lbs'
+        ? refill.quantity * 453.592
+        : refill.quantity;
+    const shots = Math.floor(grams / base);
+    const revenue = shots * sale;
+    const cost =
+      (refill.unit === 'kg'
+        ? refill.quantity
+        : refill.quantity * 0.453592) * parseFloat(refill.coffee.purchasePrice || 0);
+    const profit = revenue - cost;
+    setEspressoProjections((prev) => [
+      ...prev,
+      {
+        coffee: refill.coffee,
+        quantity: refill.quantity,
+        unit: refill.unit,
+        baseSize: base,
+        salePrice: sale,
+        shots,
+        revenue,
+        profit,
+      },
+    ]);
+    setEspressoForm({ refillIndex: '', baseSize: '', salePrice: '' });
+  };
+
+  const addFilterProjection = (e) => {
+    e.preventDefault();
+    const refill = filterRefills[filterForm.refillIndex];
+    const base = parseFloat(filterForm.baseSize);
+    const sale = parseFloat(filterForm.salePrice);
+    if (!refill || isNaN(base) || base <= 0 || isNaN(sale) || sale <= 0) return;
+    const grams =
+      refill.unit === 'kg'
+        ? refill.quantity * 1000
+        : refill.unit === 'lbs'
+        ? refill.quantity * 453.592
+        : refill.quantity;
+    const cups = Math.floor(grams / base);
+    const revenue = cups * sale;
+    const cost =
+      (refill.unit === 'kg'
+        ? refill.quantity
+        : refill.quantity * 0.453592) * parseFloat(refill.coffee.purchasePrice || 0);
+    const profit = revenue - cost;
+    setFilterProjections((prev) => [
+      ...prev,
+      {
+        coffee: refill.coffee,
+        quantity: refill.quantity,
+        unit: refill.unit,
+        baseSize: base,
+        salePrice: sale,
+        cups,
+        revenue,
+        profit,
+      },
+    ]);
+    setFilterForm({ refillIndex: '', baseSize: '20', salePrice: '' });
+  };
+
+  const handleEspressoChange = (e) => {
+    const { name, value } = e.target;
+    setEspressoForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleFilterChange = (e) => {
+    const { name, value } = e.target;
+    setFilterForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const bagRevenue = bags.reduce((sum, b) => sum + b.numBags * b.retailPrice, 0);
+  const bagProfit = bags.reduce(
+    (sum, b) => sum + b.numBags * (b.retailPrice - b.costPrice),
+    0
+  );
+  const espressoRevenue = espressoProjections.reduce((s, e) => s + e.revenue, 0);
+  const espressoProfit = espressoProjections.reduce((s, e) => s + e.profit, 0);
+  const filterRevenue = filterProjections.reduce((s, e) => s + e.revenue, 0);
+  const filterProfit = filterProjections.reduce((s, e) => s + e.profit, 0);
+  const totalRevenue = bagRevenue + espressoRevenue + filterRevenue;
+  const totalProfit = bagProfit + espressoProfit + filterProfit;
+
+  return (
+    <div className="p-4 bg-white rounded shadow-md mb-6 w-full">
+      <h2 className="text-xl font-semibold mb-3 text-dark-green">Projections</h2>
+      {bags.length > 0 && (
+        <div className="overflow-x-auto w-full mb-6">
+          <table className="min-w-full border-collapse text-sm">
+            <thead>
+              <tr className="bg-dark-green text-white">
+                <th className="border px-2 py-1 text-left">Coffee</th>
+                <th className="border px-2 py-1 text-left">Bag Weight</th>
+                <th className="border px-2 py-1 text-left">Bags</th>
+                <th className="border px-2 py-1 text-left">Cost Price</th>
+                <th className="border px-2 py-1 text-left">Retail Price</th>
+                <th className="border px-2 py-1 text-left">Revenue</th>
+                <th className="border px-2 py-1 text-left">Profit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {bags.map((b, idx) => (
+                <tr key={idx} className="odd:bg-dark-green/5 even:bg-white">
+                  <td className="border px-2 py-1">{b.coffee.name}</td>
+                  <td className="border px-2 py-1">{b.bagWeight}</td>
+                  <td className="border px-2 py-1">{b.numBags}</td>
+                  <td className="border px-2 py-1">{b.costPrice}</td>
+                  <td className="border px-2 py-1">{b.retailPrice}</td>
+                  <td className="border px-2 py-1">
+                    {(b.numBags * b.retailPrice).toFixed(2)}
+                  </td>
+                  <td className="border px-2 py-1">
+                    {(b.numBags * (b.retailPrice - b.costPrice)).toFixed(2)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <h3 className="text-lg font-semibold mb-2 text-dark-green">
+        Filter Projections
+      </h3>
+      {filterRefills.length > 0 && (
+        <form
+          onSubmit={addFilterProjection}
+          className="mb-4 flex flex-wrap gap-2 items-end"
+        >
+          <select
+            name="refillIndex"
+            value={filterForm.refillIndex}
+            onChange={handleFilterChange}
+            className="p-1 border rounded flex-1"
+            required
+          >
+            <option value="" disabled>
+              Select Refill
+            </option>
+            {filterRefills.map((r, idx) => (
+              <option key={idx} value={idx}>
+                {r.coffee.name} - {r.quantity} {r.unit}
+              </option>
+            ))}
+          </select>
+          <input
+            type="number"
+            name="baseSize"
+            value={filterForm.baseSize}
+            onChange={handleFilterChange}
+            placeholder="Base Size (g)"
+            className="p-1 border rounded w-32"
+            required
+          />
+          <input
+            type="number"
+            name="salePrice"
+            value={filterForm.salePrice}
+            onChange={handleFilterChange}
+            placeholder="Sale Price"
+            className="p-1 border rounded w-32"
+            required
+          />
+          <button
+            type="submit"
+            className="px-3 py-1 bg-dark-green text-white rounded"
+          >
+            Add Projection
+          </button>
+        </form>
+      )}
+      {filterProjections.length > 0 && (
+        <div className="overflow-x-auto w-full mb-6">
+          <table className="min-w-full border-collapse text-sm">
+            <thead>
+              <tr className="bg-dark-green text-white">
+                <th className="border px-2 py-1 text-left">Coffee</th>
+                <th className="border px-2 py-1 text-left">Quantity</th>
+                <th className="border px-2 py-1 text-left">Base Size (g)</th>
+                <th className="border px-2 py-1 text-left">Cups</th>
+                <th className="border px-2 py-1 text-left">Sale Price</th>
+                <th className="border px-2 py-1 text-left">Revenue</th>
+                <th className="border px-2 py-1 text-left">Profit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filterProjections.map((p, idx) => (
+                <tr key={idx} className="odd:bg-dark-green/5 even:bg-white">
+                  <td className="border px-2 py-1">{p.coffee.name}</td>
+                  <td className="border px-2 py-1">
+                    {p.quantity} {p.unit}
+                  </td>
+                  <td className="border px-2 py-1">{p.baseSize}</td>
+                  <td className="border px-2 py-1">{p.cups}</td>
+                  <td className="border px-2 py-1">{p.salePrice}</td>
+                  <td className="border px-2 py-1">{p.revenue.toFixed(2)}</td>
+                  <td className="border px-2 py-1">{p.profit.toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <h3 className="text-lg font-semibold mb-2 text-dark-green">
+        Espresso Projections
+      </h3>
+      {espressoRefills.length > 0 && (
+        <form
+          onSubmit={addEspressoProjection}
+          className="mb-4 flex flex-wrap gap-2 items-end"
+        >
+          <select
+            name="refillIndex"
+            value={espressoForm.refillIndex}
+            onChange={handleEspressoChange}
+            className="p-1 border rounded flex-1"
+            required
+          >
+            <option value="" disabled>
+              Select Refill
+            </option>
+            {espressoRefills.map((r, idx) => (
+              <option key={idx} value={idx}>
+                {r.coffee.name} - {r.quantity} {r.unit}
+              </option>
+            ))}
+          </select>
+          <input
+            type="number"
+            name="baseSize"
+            value={espressoForm.baseSize}
+            onChange={handleEspressoChange}
+            placeholder="Base Size (g)"
+            className="p-1 border rounded w-32"
+            required
+          />
+          <input
+            type="number"
+            name="salePrice"
+            value={espressoForm.salePrice}
+            onChange={handleEspressoChange}
+            placeholder="Sale Price"
+            className="p-1 border rounded w-32"
+            required
+          />
+          <button
+            type="submit"
+            className="px-3 py-1 bg-dark-green text-white rounded"
+          >
+            Add Projection
+          </button>
+        </form>
+      )}
+      {espressoProjections.length > 0 && (
+        <div className="overflow-x-auto w-full mb-6">
+          <table className="min-w-full border-collapse text-sm">
+            <thead>
+              <tr className="bg-dark-green text-white">
+                <th className="border px-2 py-1 text-left">Coffee</th>
+                <th className="border px-2 py-1 text-left">Quantity</th>
+                <th className="border px-2 py-1 text-left">Base Size (g)</th>
+                <th className="border px-2 py-1 text-left">Shots</th>
+                <th className="border px-2 py-1 text-left">Sale Price</th>
+                <th className="border px-2 py-1 text-left">Revenue</th>
+                <th className="border px-2 py-1 text-left">Profit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {espressoProjections.map((p, idx) => (
+                <tr key={idx} className="odd:bg-dark-green/5 even:bg-white">
+                  <td className="border px-2 py-1">{p.coffee.name}</td>
+                  <td className="border px-2 py-1">
+                    {p.quantity} {p.unit}
+                  </td>
+                  <td className="border px-2 py-1">{p.baseSize}</td>
+                  <td className="border px-2 py-1">{p.shots}</td>
+                  <td className="border px-2 py-1">{p.salePrice}</td>
+                  <td className="border px-2 py-1">{p.revenue.toFixed(2)}</td>
+                  <td className="border px-2 py-1">{p.profit.toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      <div className="text-sm">
+        <p>Total Revenue: {totalRevenue.toFixed(2)}</p>
+        <p>Total Profit: {totalProfit.toFixed(2)}</p>
+      </div>
+    </div>
+  );
+}
+
+export default Projections;

--- a/src/components/Providers.jsx
+++ b/src/components/Providers.jsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import countries from '../models/countries';
+import { useAppContext } from '../context/AppContext';
+
+function Providers() {
+  const { providers, setProviders } = useAppContext();
+  const initialForm = {
+    name: '',
+    farm: '',
+    region: '',
+    altitude: '',
+    country: '',
+  };
+
+  const [form, setForm] = useState(initialForm);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const newProvider = {
+      id: `provider${Date.now()}`,
+      ...form,
+    };
+    setProviders((prev) => [...prev, newProvider]);
+    setForm(initialForm);
+  };
+
+  return (
+    <div className="p-4 bg-white dark:bg-gray-800 dark:text-white rounded shadow-md mb-6 w-full">
+      <h2 className="text-xl font-semibold mb-3 text-dark-green">Providers</h2>
+      <form onSubmit={handleSubmit} className="grid gap-2 sm:grid-cols-2 max-w-md mx-auto mb-4">
+        <input
+          type="text"
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+          placeholder="Provider Name"
+          required
+          className="border px-2 py-1 rounded"
+        />
+        <input
+          type="text"
+          name="farm"
+          value={form.farm}
+          onChange={handleChange}
+          placeholder="Farm"
+          required
+          className="border px-2 py-1 rounded"
+        />
+        <input
+          type="text"
+          name="region"
+          value={form.region}
+          onChange={handleChange}
+          placeholder="Region"
+          required
+          className="border px-2 py-1 rounded"
+        />
+        <input
+          type="text"
+          name="altitude"
+          value={form.altitude}
+          onChange={handleChange}
+          placeholder="Altitude"
+          required
+          className="border px-2 py-1 rounded"
+        />
+        <select
+          name="country"
+          value={form.country}
+          onChange={handleChange}
+          required
+          className="border px-2 py-1 rounded"
+        >
+          <option value="">Country</option>
+          {countries.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <button
+          type="submit"
+          className="bg-dark-green text-white px-4 py-2 rounded"
+        >
+          Add Provider
+        </button>
+      </form>
+      <div className="overflow-x-auto">
+        <table className="min-w-full border-collapse text-sm">
+          <thead>
+            <tr className="bg-dark-green text-white">
+              <th className="border px-2 py-1">Name</th>
+              <th className="border px-2 py-1">Farm</th>
+              <th className="border px-2 py-1">Region</th>
+              <th className="border px-2 py-1">Altitude</th>
+              <th className="border px-2 py-1">Country</th>
+            </tr>
+          </thead>
+          <tbody>
+            {providers.map((p) => (
+              <tr key={p.id} className="odd:bg-dark-green/5 even:bg-white">
+                <td className="border px-2 py-1">{p.name}</td>
+                <td className="border px-2 py-1">{p.farm}</td>
+                <td className="border px-2 py-1">{p.region}</td>
+                <td className="border px-2 py-1">{p.altitude}</td>
+                <td className="border px-2 py-1">{p.country}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default Providers;
+

--- a/src/components/RoastedCoffee.jsx
+++ b/src/components/RoastedCoffee.jsx
@@ -1,0 +1,362 @@
+import React, { useState } from 'react';
+import countries from '../models/countries';
+import RoastedCoffeeModel from '../models/roastedCoffee';
+import { useAppContext } from '../context/AppContext';
+
+function RoastedCoffee() {
+  const { roastedCoffees, setRoastedCoffees, providers, inventory, setInventory } =
+    useAppContext();
+  const initialForm = {
+    name: '',
+    origins: [],
+    providerId: '',
+    producer: '',
+    farm: '',
+    region: '',
+    process: '',
+    varietal: '',
+    altitude: '',
+    tastingNotes: '',
+    roastLevel: '',
+    loss: '',
+    purchasePrice: '',
+  };
+
+  const [form, setForm] = useState(initialForm);
+  const [editingIndex, setEditingIndex] = useState(null);
+  const [showForm, setShowForm] = useState(false);
+  const [search, setSearch] = useState('');
+  const [toast, setToast] = useState(null);
+
+  const showToast = (message, isError = false) => {
+    setToast({ message, isError });
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleOriginChange = (e) => {
+    const selected = Array.from(e.target.selectedOptions, (o) => o.value);
+    setForm((prev) => ({ ...prev, origins: selected }));
+  };
+
+  const handleProviderChange = (e) => {
+    const providerId = e.target.value;
+    const provider = providers.find((p) => p.id === providerId);
+    setForm((prev) => ({
+      ...prev,
+      providerId,
+      producer: provider?.name || '',
+      farm: provider?.farm || '',
+      region: provider?.region || '',
+      altitude: provider?.altitude || '',
+      origins: provider ? [provider.country] : [],
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    try {
+      const updated = new RoastedCoffeeModel(form);
+      if (editingIndex !== null) {
+        setRoastedCoffees((prev) =>
+          prev.map((c, i) => (i === editingIndex ? updated : c))
+        );
+      } else {
+        setRoastedCoffees((prev) => [...prev, updated]);
+      }
+      setInventory((prev) => ({
+        ...prev,
+        roasted: { ...prev.roasted, [updated.id]: prev.roasted[updated.id] || 0 },
+      }));
+      setForm(initialForm);
+      setEditingIndex(null);
+      setShowForm(false);
+      showToast('Coffee saved');
+    } catch (err) {
+      showToast('Error saving coffee', true);
+    }
+  };
+
+  const handleEdit = (idx) => {
+    setForm({ ...roastedCoffees[idx] });
+    setEditingIndex(idx);
+    setShowForm(true);
+  };
+
+  const handleDelete = (idx) => {
+    const coffee = roastedCoffees[idx];
+    setRoastedCoffees((prev) => prev.filter((_, i) => i !== idx));
+    setInventory((prev) => {
+      const r = { ...prev.roasted };
+      delete r[coffee.id];
+      return { ...prev, roasted: r };
+    });
+    if (editingIndex === idx) {
+      setForm(initialForm);
+      setEditingIndex(null);
+      setShowForm(false);
+    }
+  };
+
+  const renderRow = (coffee, idx) => (
+    <tr key={coffee.id} className="odd:bg-dark-green/5 even:bg-white">
+      <td className="border px-2 py-1">{coffee.name}</td>
+      <td className="border px-2 py-1">{coffee.origins.join(', ')}</td>
+      <td className="border px-2 py-1">{coffee.producer}</td>
+      <td className="border px-2 py-1">{coffee.farm}</td>
+      <td className="border px-2 py-1">{coffee.region}</td>
+      <td className="border px-2 py-1">{coffee.process}</td>
+      <td className="border px-2 py-1">{coffee.varietal}</td>
+      <td className="border px-2 py-1">{coffee.altitude}</td>
+      <td className="border px-2 py-1">{coffee.tastingNotes}</td>
+      <td className="border px-2 py-1">{coffee.roastLevel}</td>
+      <td className="border px-2 py-1">{coffee.loss}</td>
+      <td className="border px-2 py-1">{inventory.roasted[coffee.id] || 0}</td>
+      <td className="border px-2 py-1">{coffee.purchasePrice}</td>
+      <td className="border px-2 py-1 text-center">
+        <button
+          type="button"
+          onClick={() => handleEdit(idx)}
+          className="text-blue-600 underline mr-2"
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          onClick={() => handleDelete(idx)}
+          className="text-red-600 underline"
+        >
+          Delete
+        </button>
+      </td>
+    </tr>
+  );
+
+  const handleAddNew = () => {
+    setForm(initialForm);
+    setEditingIndex(null);
+    setShowForm(true);
+  };
+
+  return (
+    <div className="p-4 bg-white dark:bg-gray-800 dark:text-white rounded shadow-md mb-6 w-full">
+      <h2 className="text-xl font-semibold mb-3 text-dark-green">Roasted Coffee</h2>
+      <button
+        type="button"
+        onClick={handleAddNew}
+        className="mb-4 px-3 py-1 bg-dark-green text-white rounded"
+      >
+        Add Roasted Coffee
+      </button>
+      {showForm && (
+        <form onSubmit={handleSubmit} className="mb-4 flex flex-col gap-2">
+          <input
+            type="text"
+            name="name"
+            value={form.name}
+            onChange={handleChange}
+            placeholder="Coffee Name"
+            className="p-1 border rounded"
+            required
+          />
+          <select
+            name="origins"
+            multiple
+            value={form.origins}
+            onChange={handleOriginChange}
+            className="p-1 border rounded"
+            required
+          >
+            {countries.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+          <select
+            name="providerId"
+            value={form.providerId}
+            onChange={handleProviderChange}
+            className="p-1 border rounded"
+            required
+          >
+            <option value="" disabled>
+              Provider
+            </option>
+            {providers.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name} - {p.farm} ({p.country})
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            name="producer"
+            value={form.producer}
+            onChange={handleChange}
+            placeholder="Producer Name"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="text"
+            name="farm"
+            value={form.farm}
+            onChange={handleChange}
+            placeholder="Farm"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="text"
+            name="region"
+            value={form.region}
+            onChange={handleChange}
+            placeholder="Region"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="text"
+            name="process"
+            value={form.process}
+            onChange={handleChange}
+            placeholder="Process"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="text"
+            name="varietal"
+            value={form.varietal}
+            onChange={handleChange}
+            placeholder="Varietal"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="text"
+            name="altitude"
+            value={form.altitude}
+            onChange={handleChange}
+            placeholder="Altitude"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="text"
+            name="tastingNotes"
+            value={form.tastingNotes}
+            onChange={handleChange}
+            placeholder="Tasting Notes"
+            className="p-1 border rounded"
+            required
+          />
+          <select
+            name="roastLevel"
+            value={form.roastLevel}
+            onChange={handleChange}
+            className="p-1 border rounded"
+            required
+          >
+            <option value="" disabled>
+              Roast Level
+            </option>
+            <option value="Light">Light</option>
+            <option value="Medium">Medium</option>
+            <option value="Dark">Dark</option>
+          </select>
+          <input
+            type="number"
+            name="loss"
+            value={form.loss}
+            onChange={handleChange}
+            placeholder="% Loss"
+            className="p-1 border rounded"
+            required
+          />
+          <input
+            type="number"
+            name="purchasePrice"
+            value={form.purchasePrice}
+            onChange={handleChange}
+            placeholder="Purchase Price"
+            className="p-1 border rounded"
+            required
+            step="0.01"
+          />
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="px-3 py-1 bg-dark-green text-white rounded min-w-[64px]"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setForm(initialForm);
+                setEditingIndex(null);
+                setShowForm(false);
+              }}
+              className="px-3 py-1 bg-gray-200 rounded min-w-[64px]"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+      <div className="overflow-x-auto w-full">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search..."
+          className="p-1 border rounded mb-2"
+        />
+        <table className="min-w-full border-collapse mb-8 text-sm">
+          <thead>
+            <tr className="bg-dark-green text-white">
+              <th className="border px-2 py-1 text-left">Name</th>
+              <th className="border px-2 py-1 text-left">Origins</th>
+              <th className="border px-2 py-1 text-left">Producer</th>
+              <th className="border px-2 py-1 text-left">Farm</th>
+              <th className="border px-2 py-1 text-left">Region</th>
+              <th className="border px-2 py-1 text-left">Process</th>
+              <th className="border px-2 py-1 text-left">Varietal</th>
+              <th className="border px-2 py-1 text-left">Altitude</th>
+              <th className="border px-2 py-1 text-left">Tasting Notes</th>
+              <th className="border px-2 py-1 text-left">Roast Level</th>
+              <th className="border px-2 py-1 text-left">% Loss</th>
+              <th className="border px-2 py-1 text-left">Available (kg)</th>
+              <th className="border px-2 py-1 text-left">Purchase Price</th>
+              <th className="border px-2 py-1">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {roastedCoffees
+              .filter((c) =>
+                c.name.toLowerCase().includes(search.toLowerCase())
+              )
+              .map((c, idx) => renderRow(c, idx))}
+          </tbody>
+        </table>
+      </div>
+      {toast && (
+        <div
+          className={`fixed bottom-4 right-4 px-4 py-2 rounded shadow-md text-white ${
+            toast.isError ? 'bg-red-500' : 'bg-green-500'
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default RoastedCoffee;

--- a/src/components/Sales.jsx
+++ b/src/components/Sales.jsx
@@ -1,0 +1,269 @@
+import React, { useMemo, useState } from 'react';
+import { useAppContext } from '../context/AppContext';
+
+const PAYMENT_OPTIONS = [
+  { value: 'cash', label: 'Cash' },
+  { value: 'yappy', label: 'Yappy' },
+  { value: 'card', label: 'Card' },
+  { value: 'gift_card', label: 'Gift Card' },
+];
+
+const paymentLabel = (value) => {
+  const match = PAYMENT_OPTIONS.find((option) => option.value === value);
+  return match ? match.label : value || 'Manual';
+};
+
+const normalizeSale = (sale, fallbackKey) => {
+  if (sale.items) {
+    return sale;
+  }
+
+  const bag = sale.bag || {};
+  const quantity = sale.quantity || 0;
+  const total = sale.total || 0;
+  const unitPrice =
+    bag.retailPrice || (quantity > 0 ? total / quantity : 0) || 0;
+
+  return {
+    id: sale.id || String(fallbackKey),
+    createdAt: sale.createdAt,
+    paymentMethod: sale.paymentMethod || 'manual',
+    source: sale.source,
+    items: [
+      {
+        bagName: bag.coffee?.name || sale.bagName || 'Coffee',
+        bagWeight: bag.bagWeight || sale.bagWeight || '',
+        quantity,
+        unitPrice,
+        lineTotal: total || unitPrice * quantity,
+      },
+    ],
+    total: total || unitPrice * quantity,
+    customer: sale.customer,
+  };
+};
+
+function Sales() {
+  const { sales, setSales, bags, setBags, setCustomers } = useAppContext();
+  const [form, setForm] = useState({
+    bagIndex: '',
+    quantity: '',
+    firstName: '',
+    lastName: '',
+    email: '',
+    phone: '',
+    paymentMethod: PAYMENT_OPTIONS[0].value,
+  });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const addSale = (e) => {
+    e.preventDefault();
+    const { firstName, lastName, email, phone } = form;
+    const bag = bags[form.bagIndex];
+    const qty = parseInt(form.quantity, 10);
+    if (!bag || qty <= 0 || bag.numBags < qty) return;
+    if (!email && !phone) return;
+    const total = qty * bag.retailPrice;
+    const saleRecord = {
+      id: Date.now().toString(),
+      createdAt: new Date().toISOString(),
+      paymentMethod: form.paymentMethod,
+      source: 'Manual',
+      items: [
+        {
+          bagName: bag.coffee?.name || 'Coffee',
+          bagWeight: bag.bagWeight,
+          quantity: qty,
+          unitPrice: bag.retailPrice,
+          lineTotal: total,
+        },
+      ],
+      total,
+      customer: { firstName, lastName, email, phone },
+    };
+    setSales((prev) => [...prev, saleRecord]);
+    setBags((prev) =>
+      prev.map((b, idx) =>
+        idx === parseInt(form.bagIndex, 10)
+          ? { ...b, numBags: b.numBags - qty }
+          : b
+      )
+    );
+    setCustomers((prev) => {
+      const idx = prev.findIndex(
+        (c) => (email && c.email === email) || (phone && c.phone === phone)
+      );
+      if (idx >= 0) {
+        const updated = [...prev];
+        const cust = { ...updated[idx] };
+        cust.purchases += 1;
+        cust.revenue += total;
+        if (firstName) cust.firstName = firstName;
+        if (lastName) cust.lastName = lastName;
+        if (email) cust.email = email;
+        if (phone) cust.phone = phone;
+        updated[idx] = cust;
+        return updated;
+      }
+      return [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          firstName: firstName || '',
+          lastName: lastName || '',
+          email: email || '',
+          phone: phone || '',
+          purchases: 1,
+          revenue: total,
+        },
+      ];
+    });
+    setForm({
+      bagIndex: '',
+      quantity: '',
+      firstName: '',
+      lastName: '',
+      email: '',
+      phone: '',
+      paymentMethod: PAYMENT_OPTIONS[0].value,
+    });
+  };
+
+  const normalizedSales = useMemo(
+    () => sales.map((sale, idx) => normalizeSale(sale, idx)),
+    [sales]
+  );
+
+  return (
+    <div className="p-4 w-full">
+      <h2 className="text-xl font-semibold mb-4 text-dark-green">Sales</h2>
+      <form onSubmit={addSale} className="mb-4 flex flex-wrap gap-2 items-end">
+        <input
+          type="text"
+          name="firstName"
+          value={form.firstName}
+          onChange={handleChange}
+          placeholder="First Name"
+          className="p-1 border rounded"
+        />
+        <input
+          type="text"
+          name="lastName"
+          value={form.lastName}
+          onChange={handleChange}
+          placeholder="Last Name"
+          className="p-1 border rounded"
+        />
+        <input
+          type="email"
+          name="email"
+          value={form.email}
+          onChange={handleChange}
+          placeholder="Email"
+          className="p-1 border rounded"
+        />
+        <input
+          type="tel"
+          name="phone"
+          value={form.phone}
+          onChange={handleChange}
+          placeholder="Phone"
+          className="p-1 border rounded"
+        />
+        <select
+          name="paymentMethod"
+          value={form.paymentMethod}
+          onChange={handleChange}
+          className="p-1 border rounded"
+        >
+          {PAYMENT_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <select
+          name="bagIndex"
+          value={form.bagIndex}
+          onChange={handleChange}
+          className="p-1 border rounded flex-1"
+          required
+        >
+          <option value="" disabled>
+            Select Bag
+          </option>
+          {bags.map((b, idx) => (
+            <option key={idx} value={idx}>
+              {b.coffee.name} {b.bagWeight}g ({b.numBags} available)
+            </option>
+          ))}
+        </select>
+        <input
+          type="number"
+          name="quantity"
+          value={form.quantity}
+          onChange={handleChange}
+          placeholder="Qty"
+          className="p-1 border rounded w-24"
+          required
+        />
+        <button
+          type="submit"
+          className="px-3 py-1 bg-dark-green text-white rounded"
+        >
+          Add Sale
+        </button>
+      </form>
+      {normalizedSales.length > 0 && (
+        <div className="overflow-x-auto w-full">
+          <table className="min-w-full border-collapse text-sm">
+            <thead>
+              <tr className="bg-dark-green text-white">
+                <th className="border px-2 py-1 text-left">Date</th>
+                <th className="border px-2 py-1 text-left">Items</th>
+                <th className="border px-2 py-1 text-left">Payment</th>
+                <th className="border px-2 py-1 text-left">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {normalizedSales.map((sale) => (
+                <tr key={sale.id} className="odd:bg-dark-green/5 even:bg-white">
+                  <td className="border px-2 py-1">
+                    {sale.createdAt ? new Date(sale.createdAt).toLocaleString() : '—'}
+                  </td>
+                  <td className="border px-2 py-1">
+                    <ul className="space-y-1 text-xs sm:text-sm">
+                      {sale.items.map((item, idx) => (
+                        <li key={idx}>
+                          <span className="font-semibold text-dark-green">
+                            {item.bagName}
+                          </span>{' '}
+                          <span className="text-gray-600">
+                            {item.bagWeight}g × {item.quantity}
+                          </span>
+                          <span className="ml-1 text-gray-500">
+                            (${(item.unitPrice || 0).toFixed(2)})
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </td>
+                  <td className="border px-2 py-1">{paymentLabel(sale.paymentMethod)}</td>
+                  <td className="border px-2 py-1 font-semibold">
+                    ${Number(sale.total || 0).toFixed(2)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Sales;

--- a/src/components/SideMenu.jsx
+++ b/src/components/SideMenu.jsx
@@ -1,50 +1,84 @@
 import React from 'react';
-import { FaBox, FaChartLine, FaCog, FaFileInvoiceDollar } from 'react-icons/fa';
+import {
+  FaBox,
+  FaChartLine,
+  FaCog,
+  FaFileInvoiceDollar,
+  FaCoffee,
+  FaChartBar,
+  FaTools,
+  FaLeaf,
+  FaHandshake,
+  FaCashRegister,
+  FaShoppingCart,
+  FaUser,
+  FaSeedling,
+} from 'react-icons/fa';
+import logo from '../koffeeos-logo.svg';
+import { useAppContext } from '../context/AppContext';
+
+const icons = {
+  greenCoffee: FaLeaf,
+  roastedCoffee: FaCoffee,
+  inventory: FaBox,
+  dashboard: FaChartLine,
+  projections: FaChartBar,
+  providers: FaHandshake,
+  settings: FaCog,
+  billing: FaFileInvoiceDollar,
+  management: FaTools,
+  pos: FaCashRegister,
+  sales: FaShoppingCart,
+  customers: FaUser,
+  finca: FaSeedling,
+};
 
 function SideMenu({ current, onChange, className = '' }) {
+  const { modules } = useAppContext();
+  const enabled = modules.filter((m) => m.enabled);
+  const order = [];
+  const grouped = enabled.reduce((acc, module) => {
+    const group = module.group || 'KoffeeOS Core';
+    if (!acc[group]) {
+      acc[group] = [];
+      order.push(group);
+    }
+    acc[group].push(module);
+    return acc;
+  }, {});
+
   return (
-    <nav className={`w-48 bg-beige-dark min-h-screen p-4 ${className}`}>
-      <ul className="space-y-2">
-        <li>
-          <button
-            onClick={() => onChange('inventory')}
-            className={`block w-full text-left px-2 py-1 rounded ${current === 'inventory' ? 'bg-white' : ''}`}
-          >
-            <span className="inline-flex items-center gap-1">
-              <FaBox /> <span>Inventory</span>
-            </span>
-          </button>
-        </li>
-        <li>
-          <button
-            onClick={() => onChange('dashboard')}
-            className={`block w-full text-left px-2 py-1 rounded ${current === 'dashboard' ? 'bg-white' : ''}`}
-          >
-            <span className="inline-flex items-center gap-1">
-              <FaChartLine /> <span>Dashboard</span>
-            </span>
-          </button>
-        </li>
-        <li>
-          <button
-            onClick={() => onChange('settings')}
-            className={`block w-full text-left px-2 py-1 rounded ${current === 'settings' ? 'bg-white' : ''}`}
-          >
-            <span className="inline-flex items-center gap-1">
-              <FaCog /> <span>Settings</span>
-            </span>
-          </button>
-        </li>
-        <li>
-          <button
-            onClick={() => onChange('billing')}
-            className={`block w-full text-left px-2 py-1 rounded ${current === 'billing' ? 'bg-white' : ''}`}
-          >
-            <span className="inline-flex items-center gap-1">
-              <FaFileInvoiceDollar /> <span>Billing</span>
-            </span>
-          </button>
-        </li>
+    <nav className={`w-48 bg-dark-green text-white min-h-screen p-4 ${className}`}>
+      <div className="mb-6 flex justify-center">
+        <img src={logo} alt="logo" className="w-24" />
+      </div>
+      <ul className="space-y-4">
+        {order.map((group) => (
+          <li key={group}>
+            <p className="text-xs uppercase tracking-wide text-white/60 mb-1">
+              {group}
+            </p>
+            <ul className="space-y-2">
+              {grouped[group].map((m) => {
+                const Icon = icons[m.key] || FaCoffee;
+                return (
+                  <li key={m.key}>
+                    <button
+                      onClick={() => onChange(m.key)}
+                      className={`block w-full text-left px-2 py-1 rounded ${
+                        current === m.key ? 'bg-white text-dark-green' : ''
+                      }`}
+                    >
+                      <span className="inline-flex items-center gap-1">
+                        <Icon /> <span>{m.name}</span>
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </li>
+        ))}
       </ul>
     </nav>
   );

--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -1,0 +1,143 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import greenCoffeeData from '../models/greenCoffeeData';
+import roastedCoffeeData from '../models/roastedCoffeeData';
+import providersData from '../models/providers';
+import modulesData from '../models/modules';
+import inventoryData from '../models/inventory';
+import customersData from '../models/customers';
+import fincaLotsData from '../models/fincaLots';
+import companiesData from '../models/companies';
+
+const dashboardKpiOptions = [
+  {
+    id: 'weeklySales',
+    label: 'Weekly Sales Trend',
+    description: 'Track revenue momentum across recent weeks.',
+  },
+  {
+    id: 'productMix',
+    label: 'Product Mix',
+    description: 'Understand which products drive the most sales.',
+  },
+  {
+    id: 'greenInventory',
+    label: 'Green Coffee Inventory',
+    description: 'Monitor available raw coffee to plan roasting.',
+  },
+  {
+    id: 'roastedInventory',
+    label: 'Roasted Coffee Inventory',
+    description: 'Ensure finished coffee supply meets demand.',
+  },
+  {
+    id: 'bagInventory',
+    label: 'Bags Ready for Sale',
+    description: 'Keep an eye on packaged product availability.',
+  },
+  {
+    id: 'projectionSummary',
+    label: 'Revenue & Profit Projections',
+    description: 'Forecast income based on pricing and costs.',
+  },
+];
+
+const AppContext = createContext();
+
+export const AppProvider = ({ children, initialState = {} }) => {
+  const initialCompanies = initialState.companies || companiesData;
+  const [companies, setCompanies] = useState(initialCompanies);
+  const defaultCompanyId =
+    initialState.activeCompanyId || (initialCompanies[0] ? initialCompanies[0].id : null);
+  const [activeCompanyId, setActiveCompanyId] = useState(defaultCompanyId);
+  const [greenCoffees, setGreenCoffees] = useState(initialState.greenCoffees || greenCoffeeData);
+  const [roastedCoffees, setRoastedCoffees] = useState(initialState.roastedCoffees || roastedCoffeeData);
+  const [inventory, setInventory] = useState(initialState.inventory || inventoryData);
+  const [bags, setBags] = useState(initialState.bags || []);
+  const [espressoRefills, setEspressoRefills] = useState(initialState.espressoRefills || []);
+  const [espressoProjections, setEspressoProjections] = useState(initialState.espressoProjections || []);
+  const [filterRefills, setFilterRefills] = useState(initialState.filterRefills || []);
+  const [filterProjections, setFilterProjections] = useState(initialState.filterProjections || []);
+  const [modules, setModules] = useState(initialState.modules || modulesData);
+  const [providers, setProviders] = useState(initialState.providers || providersData);
+  const [sales, setSales] = useState(initialState.sales || []);
+  const [customers, setCustomers] = useState(initialState.customers || customersData);
+  const [darkMode, setDarkMode] = useState(initialState.darkMode || false);
+  const [fincaLots, setFincaLots] = useState(initialState.fincaLots || fincaLotsData);
+  const defaultKpis = dashboardKpiOptions.map((kpi) => kpi.id);
+  const [dashboardKpis, setDashboardKpis] = useState(
+    initialState.dashboardKpis || defaultKpis
+  );
+
+  useEffect(() => {
+    if (!companies.length) {
+      setActiveCompanyId(null);
+      return;
+    }
+    if (!companies.some((company) => company.id === activeCompanyId)) {
+      setActiveCompanyId(companies[0].id);
+    }
+  }, [companies, activeCompanyId]);
+
+  useEffect(() => {
+    setInventory((prev) => {
+      const green = {};
+      greenCoffees.forEach((c) => {
+        green[c.id] = prev.green[c.id] || 0;
+      });
+      const roasted = {};
+      roastedCoffees.forEach((c) => {
+        roasted[c.id] = prev.roasted[c.id] || 0;
+      });
+      return { ...prev, green, roasted };
+    });
+  }, [greenCoffees, roastedCoffees]);
+
+  const activeCompany = useMemo(
+    () => companies.find((company) => company.id === activeCompanyId) || null,
+    [companies, activeCompanyId]
+  );
+
+  const value = {
+    companies,
+    setCompanies,
+    activeCompany,
+    activeCompanyId,
+    setActiveCompanyId,
+    greenCoffees,
+    setGreenCoffees,
+    roastedCoffees,
+    setRoastedCoffees,
+    inventory,
+    setInventory,
+    bags,
+    setBags,
+    espressoRefills,
+    setEspressoRefills,
+    espressoProjections,
+    setEspressoProjections,
+    filterRefills,
+    setFilterRefills,
+    filterProjections,
+    setFilterProjections,
+    modules,
+    setModules,
+    providers,
+    setProviders,
+    sales,
+    setSales,
+    customers,
+    setCustomers,
+    darkMode,
+    setDarkMode,
+    fincaLots,
+    setFincaLots,
+    dashboardKpis,
+    setDashboardKpis,
+    dashboardKpiOptions,
+  };
+
+  return <AppContext.Provider value={value}>{children}</AppContext.Provider>;
+};
+
+export const useAppContext = () => useContext(AppContext);
+

--- a/src/index.css
+++ b/src/index.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply bg-beige text-gray-800 font-sans;
+  @apply bg-white text-dark-green font-sans dark:bg-gray-900 dark:text-white;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { AppProvider } from './context/AppContext';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <AppProvider>
+      <App />
+    </AppProvider>
   </React.StrictMode>
 );
 

--- a/src/models/coffee.js
+++ b/src/models/coffee.js
@@ -1,0 +1,38 @@
+const generateId = () => Math.random().toString(36).substring(2, 11);
+
+class Coffee {
+  constructor({
+    id = generateId(),
+    name = '',
+    origins = [],
+    providerId = '',
+    producer = '',
+    farm = '',
+    region = '',
+    process = '',
+    varietal = '',
+    altitude = '',
+    tastingNotes = '',
+    isRoasted = false,
+    purchasePrice = '',
+  } = {}) {
+    Object.assign(this, {
+      id,
+      name,
+      origins,
+      providerId,
+      producer,
+      farm,
+      region,
+      process,
+      varietal,
+      altitude,
+      tastingNotes,
+      isRoasted,
+      purchasePrice,
+    });
+  }
+}
+
+export default Coffee;
+

--- a/src/models/companies.js
+++ b/src/models/companies.js
@@ -1,0 +1,22 @@
+const companies = [
+  {
+    id: 'pulpa-roasters',
+    name: 'Pulpa Roasters',
+    location: 'Panama City, Panama',
+    plan: 'Growth',
+  },
+  {
+    id: 'isthmus-coffee',
+    name: 'Isthmus Coffee Lab',
+    location: 'Boquete, Panama',
+    plan: 'Starter',
+  },
+  {
+    id: 'canal-cafe',
+    name: 'Canal Café',
+    location: 'Panama City, Panama',
+    plan: 'Starter',
+  },
+];
+
+export default companies;

--- a/src/models/countries.js
+++ b/src/models/countries.js
@@ -1,0 +1,19 @@
+const countries = [
+  'Guatemala',
+  'Ethiopia',
+  'Colombia',
+  'Brazil',
+  'Costa Rica',
+  'Kenya',
+  'Panama',
+  'Honduras',
+  'Nicaragua',
+  'El Salvador',
+  'Peru',
+  'Mexico',
+  'Rwanda',
+  'Burundi',
+  'Tanzania',
+];
+
+export default countries;

--- a/src/models/customers.js
+++ b/src/models/customers.js
@@ -1,0 +1,3 @@
+const customers = [];
+
+export default customers;

--- a/src/models/fincaLots.js
+++ b/src/models/fincaLots.js
@@ -1,0 +1,3 @@
+const fincaLots = [];
+
+export default fincaLots;

--- a/src/models/greenCoffeeData.js
+++ b/src/models/greenCoffeeData.js
@@ -1,0 +1,19 @@
+import Coffee from './coffee';
+
+const greenCoffeeData = [
+  new Coffee({
+    name: 'Guatemala Huehuetenango',
+    origins: ['Guatemala'],
+    providerId: 'provider1',
+    producer: 'Juan Perez',
+    farm: 'Finca La Esperanza',
+    region: 'Huehuetenango',
+    process: 'Washed',
+    varietal: 'Bourbon',
+    altitude: '1800m',
+    tastingNotes: 'Chocolate, Citrus',
+    purchasePrice: '5.00',
+  }),
+];
+
+export default greenCoffeeData;

--- a/src/models/inventory.js
+++ b/src/models/inventory.js
@@ -1,0 +1,9 @@
+class Inventory {
+  constructor({ green = {}, roasted = {}, consumables = {} } = {}) {
+    this.green = green; // {coffeeId: quantityKg}
+    this.roasted = roasted; // {coffeeId: quantityKg}
+    this.consumables = consumables; // {itemId: quantity}
+  }
+}
+
+export default new Inventory();

--- a/src/models/modules.js
+++ b/src/models/modules.js
@@ -1,0 +1,36 @@
+import {
+  FaBox,
+  FaChartBar,
+  FaChartLine,
+  FaCoffee,
+  FaCog,
+  FaFileInvoiceDollar,
+  FaTools,
+  FaLeaf,
+  FaHandshake,
+  FaCashRegister,
+  FaShoppingCart,
+  FaUser,
+  FaSeedling,
+} from 'react-icons/fa';
+
+const CORE = 'KoffeeOS Core';
+const FINCA = 'KoffeeOS Finca';
+
+const modules = [
+  { key: 'dashboard', name: 'Dashboard', icon: FaChartLine, enabled: true, group: CORE },
+  { key: 'greenCoffee', name: 'Green Coffee', icon: FaLeaf, enabled: true, group: CORE },
+  { key: 'roastedCoffee', name: 'Roasted Coffee', icon: FaCoffee, enabled: true, group: CORE },
+  { key: 'inventory', name: 'Inventory', icon: FaBox, enabled: true, group: CORE },
+  { key: 'projections', name: 'Projections', icon: FaChartBar, enabled: true, group: CORE },
+  { key: 'pos', name: 'POS', icon: FaCashRegister, enabled: true, group: CORE },
+  { key: 'sales', name: 'Sales', icon: FaShoppingCart, enabled: true, group: CORE },
+  { key: 'customers', name: 'Customers', icon: FaUser, enabled: true, group: CORE },
+  { key: 'providers', name: 'Providers', icon: FaHandshake, enabled: true, group: CORE },
+  { key: 'settings', name: 'Settings', icon: FaCog, enabled: true, group: CORE },
+  { key: 'billing', name: 'Billing', icon: FaFileInvoiceDollar, enabled: true, group: CORE },
+  { key: 'finca', name: 'Finca', icon: FaSeedling, enabled: true, group: FINCA },
+  { key: 'management', name: 'Management', icon: FaTools, enabled: true, group: CORE },
+];
+
+export default modules;

--- a/src/models/providers.js
+++ b/src/models/providers.js
@@ -1,0 +1,20 @@
+const providers = [
+  {
+    id: 'provider1',
+    name: 'Juan Perez',
+    farm: 'Finca La Esperanza',
+    region: 'Huehuetenango',
+    altitude: '1800m',
+    country: 'Guatemala',
+  },
+  {
+    id: 'provider2',
+    name: 'Abebe',
+    farm: 'Heirloom Farm',
+    region: 'Yirgacheffe',
+    altitude: '2000m',
+    country: 'Ethiopia',
+  },
+];
+
+export default providers;

--- a/src/models/roastedCoffee.js
+++ b/src/models/roastedCoffee.js
@@ -1,0 +1,12 @@
+import Coffee from './coffee';
+
+class RoastedCoffee extends Coffee {
+  constructor({ id, roastLevel = '', loss = '', purchasePrice = '', ...rest } = {}) {
+    super({ id, ...rest, isRoasted: true, purchasePrice });
+    this.roastLevel = roastLevel;
+    this.loss = loss;
+  }
+}
+
+export default RoastedCoffee;
+

--- a/src/models/roastedCoffeeData.js
+++ b/src/models/roastedCoffeeData.js
@@ -1,0 +1,21 @@
+import RoastedCoffee from './roastedCoffee';
+
+const roastedCoffeeData = [
+  new RoastedCoffee({
+    name: 'Ethiopia Yirgacheffe',
+    origins: ['Ethiopia'],
+    providerId: 'provider2',
+    producer: 'Abebe',
+    farm: 'Heirloom Farm',
+    region: 'Yirgacheffe',
+    process: 'Natural',
+    varietal: 'Heirloom',
+    altitude: '2000m',
+    tastingNotes: 'Floral, Berry',
+    roastLevel: 'Light',
+    loss: '12',
+    purchasePrice: '15.00',
+  }),
+];
+
+export default roastedCoffeeData;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,12 @@
 module.exports = {
+  darkMode: 'class',
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
     extend: {
       colors: {
         beige: '#f5f5dc',
         'beige-dark': '#e5e1c6',
+        'dark-green': '#064e3b',
       },
     },
   },


### PR DESCRIPTION
## Summary
- surface a company selector modal at login with an upgrade prompt so users choose among existing companies or jump to billing to add more
- extend the app context with company data and dashboard KPI preferences backed by a seeded company catalog
- let dashboard KPIs be configured through a modal, showing only the metrics a roastery wants to track by default

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a8ee6b95bc832f8941b1e611cc4b1b